### PR TITLE
style: allow unused method parameters to have a leading underscore

### DIFF
--- a/common/changes/@aws/swb-app/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
+++ b/common/changes/@aws/swb-app/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-app",
+      "comment": "Allow unused method parameters to have a leading underscore",
+      "type": "none"
+    }
+  ],
+  "packageName": "@aws/swb-app"
+}

--- a/common/changes/@aws/workbench-core-accounts/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
+++ b/common/changes/@aws/workbench-core-accounts/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-accounts",
+      "comment": "Allow unused method parameters to have a leading underscore",
+      "type": "none"
+    }
+  ],
+  "packageName": "@aws/workbench-core-accounts"
+}

--- a/common/changes/@aws/workbench-core-audit/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
+++ b/common/changes/@aws/workbench-core-audit/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-audit",
+      "comment": "Allow unused method parameters to have a leading underscore",
+      "type": "none"
+    }
+  ],
+  "packageName": "@aws/workbench-core-audit"
+}

--- a/common/changes/@aws/workbench-core-authentication/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
+++ b/common/changes/@aws/workbench-core-authentication/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-authentication",
+      "comment": "Allow unused method parameters to have a leading underscore",
+      "type": "none"
+    }
+  ],
+  "packageName": "@aws/workbench-core-authentication"
+}

--- a/common/changes/@aws/workbench-core-authorization/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
+++ b/common/changes/@aws/workbench-core-authorization/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-authorization",
+      "comment": "Allow unused method parameters to have a leading underscore",
+      "type": "none"
+    }
+  ],
+  "packageName": "@aws/workbench-core-authorization"
+}

--- a/common/changes/@aws/workbench-core-datasets/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
+++ b/common/changes/@aws/workbench-core-datasets/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-datasets",
+      "comment": "Allow unused method parameters to have a leading underscore",
+      "type": "none"
+    }
+  ],
+  "packageName": "@aws/workbench-core-datasets"
+}

--- a/common/changes/@aws/workbench-core-environments-ui/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
+++ b/common/changes/@aws/workbench-core-environments-ui/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-environments-ui",
+      "comment": "Allow unused method parameters to have a leading underscore",
+      "type": "none"
+    }
+  ],
+  "packageName": "@aws/workbench-core-environments-ui"
+}

--- a/common/changes/@aws/workbench-core-logging/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
+++ b/common/changes/@aws/workbench-core-logging/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-logging",
+      "comment": "Allow unused method parameters to have a leading underscore",
+      "type": "none"
+    }
+  ],
+  "packageName": "@aws/workbench-core-logging"
+}

--- a/common/changes/@aws/workbench-core-swb-common-ui/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
+++ b/common/changes/@aws/workbench-core-swb-common-ui/topic-allowUnusedParamsHavingLeadingUnderscore_2023-04-18-17-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-swb-common-ui",
+      "comment": "Allow unused method parameters to have a leading underscore",
+      "type": "none"
+    }
+  ],
+  "packageName": "@aws/workbench-core-swb-common-ui"
+}

--- a/solutions/swb-app/src/projectEnvironmentRoutes.ts
+++ b/solutions/swb-app/src/projectEnvironmentRoutes.ts
@@ -238,7 +238,7 @@ export function setUpProjectEnvRoutes(
   // Get environment
   router.get(
     '/projects/:projectId/environments/:id',
-    wrapAsync(async (req: Request, res: Response, next: NextFunction) => {
+    wrapAsync(async (req: Request, res: Response, _next: NextFunction) => {
       const validatedRequest = validateAndParse<GetEnvironmentRequest>(GetEnvironmentRequestParser, {
         environmentId: req.params.id,
         projectId: req.params.projectId

--- a/solutions/swb-reference/src/constants.ts
+++ b/solutions/swb-reference/src/constants.ts
@@ -240,7 +240,7 @@ function getDynamicAuthTableName(): string {
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     fs.readFileSync(join(__dirname, `../../src/config/${process.env.STAGE}.json`), 'utf8') // nosemgrep
   );
-  const stackName = Object.entries(outputs).map(([key, value]) => key)[0]; //output has a format { stackname: {...props} }
+  const stackName = Object.entries(outputs).map(([key, _value]) => key)[0]; //output has a format { stackname: {...props} }
   // eslint-disable-next-line security/detect-object-injection
   return outputs[stackName].dynamicAuthDDBTableName;
 }

--- a/solutions/swb-reference/src/mocks/mockDatabaseService.ts
+++ b/solutions/swb-reference/src/mocks/mockDatabaseService.ts
@@ -44,7 +44,7 @@ export class MockDatabaseService implements DatabaseServicePlugin {
     this._associations.set(key, associations.concat(relations));
   }
 
-  private _deleteAssociations(entity: Associable, relations: Associable[]): void {
+  private _deleteAssociations(entity: Associable, _relations: Associable[]): void {
     const key = this._keyForAssociable(entity);
     let associations = this._associations.get(key) || [];
 

--- a/solutions/swb-reference/src/services/dataSetService.test.ts
+++ b/solutions/swb-reference/src/services/dataSetService.test.ts
@@ -367,7 +367,7 @@ describe('DataSetService', () => {
         };
 
         mockDynamicAuthService.createIdentityPermissions = jest.fn(
-          (request: CreateIdentityPermissionsRequest): Promise<CreateIdentityPermissionsResponse> => {
+          (_request: CreateIdentityPermissionsRequest): Promise<CreateIdentityPermissionsResponse> => {
             return Promise.resolve({
               data: {
                 identityPermissions: []
@@ -489,7 +489,7 @@ describe('DataSetService', () => {
         };
 
         mockDynamicAuthService.deleteIdentityPermissions = jest.fn(
-          (request: DeleteIdentityPermissionsRequest): Promise<DeleteIdentityPermissionsResponse> => {
+          (_request: DeleteIdentityPermissionsRequest): Promise<DeleteIdentityPermissionsResponse> => {
             return Promise.resolve({
               data: {
                 identityPermissions: []

--- a/solutions/swb-reference/src/services/databaseService.ts
+++ b/solutions/swb-reference/src/services/databaseService.ts
@@ -53,7 +53,7 @@ export class DatabaseService implements DatabaseServicePlugin {
     }
   }
 
-  public getAssociations(type: string, id: string): Promise<Associable[]> {
+  public getAssociations(_type: string, _id: string): Promise<Associable[]> {
     return Promise.resolve([]);
   }
 

--- a/solutions/swb-reference/src/services/projectEnvTypeConfigService.ts
+++ b/solutions/swb-reference/src/services/projectEnvTypeConfigService.ts
@@ -237,7 +237,7 @@ export class ProjectEnvTypeConfigService implements ProjectEnvTypeConfigPlugin {
     projectId: string,
     envTypeId: string,
     envTypeConfigId: string,
-    user: AuthenticatedUser
+    _user: AuthenticatedUser
   ): Promise<void> {
     const typeId = `${resourceTypeToKey.envType}#${envTypeId}${resourceTypeToKey.envTypeConfig}#${envTypeConfigId}`;
     let paginationToken: string | undefined = undefined;

--- a/solutions/swb-reference/src/services/sshKeyService.test.ts
+++ b/solutions/swb-reference/src/services/sshKeyService.test.ts
@@ -176,7 +176,7 @@ describe('SshKeyService', () => {
             test('it succeeds, and response with a list of multiple sshKeys is returned', async () => {
               // BUILD
               mockResponse = { sshKeys: [] };
-              keyPairs.forEach((key) => {
+              keyPairs.forEach((_key) => {
                 mockResponse.sshKeys.push({
                   sshKeyId: mockKeyName,
                   createTime: mockCreateTime.toISOString(),

--- a/workbench-core/accounts/src/handlers/accountHandler.ts
+++ b/workbench-core/accounts/src/handlers/accountHandler.ts
@@ -22,7 +22,7 @@ export default class AccountHandler {
     this._accountService = accountService;
   }
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
-  public async execute(event: any): Promise<void> {
+  public async execute(_event: any): Promise<void> {
     // eslint-disable-next-line
     const hostingAccounts = await this._getAccountMetadata();
     const portfolioName = process.env.SC_PORTFOLIO_NAME!;

--- a/workbench-core/accounts/src/services/projectService.test.ts
+++ b/workbench-core/accounts/src/services/projectService.test.ts
@@ -1762,13 +1762,13 @@ describe('ProjectService', () => {
 
     let projectId: string;
     let request: DeleteProjectRequest;
-    let checkDependency = async function (projectId: string): Promise<void> {
+    let checkDependency = async function (_projectId: string): Promise<void> {
       return;
     };
 
     beforeEach(() => {
       request = { authenticatedUser: user, projectId };
-      checkDependency = async function (projectId: string): Promise<void> {
+      checkDependency = async function (_projectId: string): Promise<void> {
         return;
       };
     });

--- a/workbench-core/audit/src/__mocks__/auditService.ts
+++ b/workbench-core/audit/src/__mocks__/auditService.ts
@@ -8,11 +8,11 @@ import Metadata from '../metadata';
 
 export default class AuditService {
   public constructor(
-    auditPlugin: AuditPlugin,
-    continueOnError: boolean = false,
-    requiredAuditValues: string[] = ['actor', 'source', 'statusCode', 'action'],
-    fieldsToMask: string[] = ['password', 'accessKey']
+    _auditPlugin: AuditPlugin,
+    _continueOnError: boolean = false,
+    _requiredAuditValues: string[] = ['actor', 'source', 'statusCode', 'action'],
+    _fieldsToMask: string[] = ['password', 'accessKey']
   ) {}
 
-  public async write(metadata: Metadata, body?: object): Promise<void> {}
+  public async write(_metadata: Metadata, _body?: object): Promise<void> {}
 }

--- a/workbench-core/audit/src/__mocks__/baseExtractor.ts
+++ b/workbench-core/audit/src/__mocks__/baseExtractor.ts
@@ -14,7 +14,7 @@ export const mockMetadata: Metadata = {
 };
 
 export const BaseExtractor: Extractor = {
-  getMetadata: jest.fn((req: Request, res: Response): Metadata => {
+  getMetadata: jest.fn((_req: Request, _res: Response): Metadata => {
     return {
       action: 'GET /user',
       source: { ip: 'sampleIp' },

--- a/workbench-core/audit/src/auditService.test.ts
+++ b/workbench-core/audit/src/auditService.test.ts
@@ -36,7 +36,7 @@ describe('Audit Service', () => {
       ipAddress: 'sampleIPAddress'
     };
     mockAuditPlugin = {
-      write: jest.fn(async (metadata: Metadata, auditEntry: Readonly<AuditEntry>): Promise<void> => {}),
+      write: jest.fn(async (_metadata: Metadata, _auditEntry: Readonly<AuditEntry>): Promise<void> => {}),
       prepare: jest.fn(async (metadata: Metadata, auditEntry: AuditEntry): Promise<void> => {
         auditEntry.action = metadata.action;
         auditEntry.statusCode = metadata.statusCode;

--- a/workbench-core/authentication/src/__mocks__/authenticationService.ts
+++ b/workbench-core/authentication/src/__mocks__/authenticationService.ts
@@ -23,7 +23,7 @@ export const tokens = {
 } as const;
 
 export class AuthenticationService {
-  public constructor(authenticationPlugin: AuthenticationPlugin) {}
+  public constructor(_authenticationPlugin: AuthenticationPlugin) {}
 
   public async isUserLoggedIn(accessToken: string): Promise<boolean> {
     if (accessToken === 'validToken') {
@@ -48,18 +48,18 @@ export class AuthenticationService {
     throw new Error();
   }
 
-  public getUserIdFromToken(decodedToken: DecodedJWT): string {
+  public getUserIdFromToken(_decodedToken: DecodedJWT): string {
     return 'id';
   }
 
-  public getUserRolesFromToken(decodedToken: DecodedJWT): string[] {
+  public getUserRolesFromToken(_decodedToken: DecodedJWT): string[] {
     return ['role'];
   }
 
   public async handleAuthorizationCode(
     code: string,
     codeVerifier: string,
-    websiteUrl: string
+    _websiteUrl: string
   ): Promise<Tokens> {
     if (code === 'validCode' && codeVerifier === 'validCodeVerifier') {
       return tokens;

--- a/workbench-core/authentication/src/__mocks__/utils.ts
+++ b/workbench-core/authentication/src/__mocks__/utils.ts
@@ -10,6 +10,6 @@ export enum TimeUnits {
   SECONDS = 'seconds'
 }
 
-export function getTimeInMS(length: number, units: TimeUnits): number {
+export function getTimeInMS(_length: number, _units: TimeUnits): number {
   return 1;
 }

--- a/workbench-core/authentication/src/authenticationMiddleware.test.ts
+++ b/workbench-core/authentication/src/authenticationMiddleware.test.ts
@@ -57,11 +57,11 @@ describe('authenticationMiddleware tests', () => {
 
   beforeEach(() => {
     res = {
-      cookie: jest.fn((name, val, opts) => res),
-      clearCookie: jest.fn((name, opts) => res),
-      status: jest.fn((code) => res),
-      sendStatus: jest.fn((code) => res),
-      json: jest.fn((body) => res),
+      cookie: jest.fn((_name, _val, _opts) => res),
+      clearCookie: jest.fn((_name, _opts) => res),
+      status: jest.fn((_code) => res),
+      sendStatus: jest.fn((_code) => res),
+      json: jest.fn((_body) => res),
       locals: {}
     } as unknown as Response;
   });

--- a/workbench-core/authentication/src/plugins/__mocks__/cognitoAuthenticationPlugin.ts
+++ b/workbench-core/authentication/src/plugins/__mocks__/cognitoAuthenticationPlugin.ts
@@ -9,14 +9,14 @@ import { Tokens } from '../../tokens';
 import { CognitoAuthenticationPluginOptions } from '../cognitoAuthenticationPlugin';
 
 export class CognitoAuthenticationPlugin implements AuthenticationPlugin {
-  public constructor(options: CognitoAuthenticationPluginOptions) {}
+  public constructor(_options: CognitoAuthenticationPluginOptions) {}
   public async isUserLoggedIn(accessToken: string): Promise<boolean> {
     if (accessToken) {
       return true;
     }
     return false;
   }
-  public async validateToken(token: string): Promise<CognitoJwtPayload> {
+  public async validateToken(_token: string): Promise<CognitoJwtPayload> {
     return Promise.resolve({
       token_use: 'access',
       sub: 'sub',
@@ -28,17 +28,17 @@ export class CognitoAuthenticationPlugin implements AuthenticationPlugin {
       origin_jti: 'origin_jti'
     });
   }
-  public async revokeToken(refreshToken: string): Promise<void> {}
-  public getUserIdFromToken(decodedToken: CognitoJwtPayload): string {
+  public async revokeToken(_refreshToken: string): Promise<void> {}
+  public getUserIdFromToken(_decodedToken: CognitoJwtPayload): string {
     return 'id';
   }
-  public getUserRolesFromToken(decodedToken: CognitoJwtPayload): string[] {
+  public getUserRolesFromToken(_decodedToken: CognitoJwtPayload): string[] {
     return ['role'];
   }
   public async handleAuthorizationCode(
-    code: string,
-    codeVerifier: string,
-    websiteUrl: string
+    _code: string,
+    _codeVerifier: string,
+    _websiteUrl: string
   ): Promise<Tokens> {
     return Promise.resolve({
       idToken: {
@@ -58,7 +58,7 @@ export class CognitoAuthenticationPlugin implements AuthenticationPlugin {
   public getAuthorizationCodeUrl(state: string, codeChallenge: string, websiteUrl: string): string {
     return `https://www.fakeurl.com/authorize?client_id=fake-id&response_type=code&scope=openid&redirect_uri=${websiteUrl}&state=${state}&code_challenge_method=S256&code_challenge=${codeChallenge}`;
   }
-  public async refreshAccessToken(refreshToken: string): Promise<Tokens> {
+  public async refreshAccessToken(_refreshToken: string): Promise<Tokens> {
     return Promise.resolve({
       idToken: {
         token: 'id token',

--- a/workbench-core/authorization/src/__mocks__/authorizationPlugin.ts
+++ b/workbench-core/authorization/src/__mocks__/authorizationPlugin.ts
@@ -13,8 +13,8 @@ import {
 
 export class MockAuthorizationPlugin implements AuthorizationPlugin {
   public async isAuthorizedOnDynamicOperations(
-    identityPermissions: IdentityPermission[],
-    dynamicOperations: DynamicOperation[]
+    _identityPermissions: IdentityPermission[],
+    _dynamicOperations: DynamicOperation[]
   ): Promise<void> {
     throw new Error('Method not implemented.');
   }

--- a/workbench-core/authorization/src/authorizationMiddleware.test.ts
+++ b/workbench-core/authorization/src/authorizationMiddleware.test.ts
@@ -104,7 +104,7 @@ describe('authorization middleware', () => {
       locals: {
         user: mockGuest
       },
-      status: jest.fn().mockImplementation((statusCode: number) => {
+      status: jest.fn().mockImplementation((_statusCode: number) => {
         return response;
       }),
       json: jest.fn()
@@ -125,7 +125,7 @@ describe('authorization middleware', () => {
       locals: {
         user: mockGuest
       },
-      status: jest.fn().mockImplementation((statusCode: number) => {
+      status: jest.fn().mockImplementation((_statusCode: number) => {
         return response;
       }),
       json: jest.fn()
@@ -146,7 +146,7 @@ describe('authorization middleware', () => {
       locals: {
         user: mockGuest
       },
-      status: jest.fn().mockImplementation((statusCode: number) => {
+      status: jest.fn().mockImplementation((_statusCode: number) => {
         return response;
       }),
       json: jest.fn()
@@ -164,7 +164,7 @@ describe('authorization middleware', () => {
     const next = jest.fn();
     const response: Response = {
       locals: {},
-      status: jest.fn().mockImplementation((statusCode: number) => {
+      status: jest.fn().mockImplementation((_statusCode: number) => {
         return response;
       }),
       json: jest.fn()
@@ -187,7 +187,7 @@ describe('authorization middleware', () => {
           roles: ['guest']
         }
       },
-      status: jest.fn().mockImplementation((statusCode: number) => {
+      status: jest.fn().mockImplementation((_statusCode: number) => {
         return response;
       }),
       json: jest.fn()
@@ -210,7 +210,7 @@ describe('authorization middleware', () => {
           id: 'sampleId'
         }
       },
-      status: jest.fn().mockImplementation((statusCode: number) => {
+      status: jest.fn().mockImplementation((_statusCode: number) => {
         return response;
       }),
       json: jest.fn()
@@ -244,7 +244,7 @@ describe('authorization middleware', () => {
           id: 'sampleId'
         }
       },
-      status: jest.fn().mockImplementation((statusCode: number) => {
+      status: jest.fn().mockImplementation((_statusCode: number) => {
         return response;
       }),
       json: jest.fn()

--- a/workbench-core/authorization/src/dynamicAuthorization/ddbDynamicAuthorizationPermissionsPlugin.test.ts
+++ b/workbench-core/authorization/src/dynamicAuthorization/ddbDynamicAuthorizationPermissionsPlugin.test.ts
@@ -296,7 +296,7 @@ describe('DDB Dynamic Authorization Permissions Plugin tests', () => {
     itProp(
       `get operations by route with a valid route but invalid method should throw RouteNotFoundError`,
       [fc.string()],
-      async (route) => {
+      async (_route) => {
         await expect(
           dynamoDBDynamicPermissionsPlugin.getDynamicOperationsByRoute({
             route: '/dynamic/sampleSubjectType/sampleSubjectId',

--- a/workbench-core/authorization/src/dynamicAuthorization/dynamicAuthorizationMiddleware.test.ts
+++ b/workbench-core/authorization/src/dynamicAuthorization/dynamicAuthorizationMiddleware.test.ts
@@ -110,7 +110,7 @@ describe('dynamicAuthorizationMiddleware tests', () => {
   test('missing user should return a 403', async () => {
     const next = jest.fn();
     const response: Response = {
-      status: jest.fn().mockImplementation((statusCode: number) => {
+      status: jest.fn().mockImplementation((_statusCode: number) => {
         return response;
       }),
       json: jest.fn()
@@ -132,7 +132,7 @@ describe('dynamicAuthorizationMiddleware tests', () => {
       locals: {
         user: mockUser
       },
-      status: jest.fn().mockImplementation((statusCode: number) => {
+      status: jest.fn().mockImplementation((_statusCode: number) => {
         return response;
       }),
       json: jest.fn()
@@ -153,7 +153,7 @@ describe('dynamicAuthorizationMiddleware tests', () => {
       locals: {
         user: mockUser
       },
-      status: jest.fn().mockImplementation((statusCode: number) => {
+      status: jest.fn().mockImplementation((_statusCode: number) => {
         return response;
       }),
       json: jest.fn()
@@ -178,7 +178,7 @@ describe('dynamicAuthorizationMiddleware tests', () => {
       locals: {
         user: mockUser
       },
-      status: jest.fn().mockImplementation((statusCode: number) => {
+      status: jest.fn().mockImplementation((_statusCode: number) => {
         return response;
       }),
       json: jest.fn()

--- a/workbench-core/datasets/src/dataSetService.test.ts
+++ b/workbench-core/datasets/src/dataSetService.test.ts
@@ -168,7 +168,7 @@ describe('DataSetService', () => {
 
     jest
       .spyOn(DdbDataSetMetadataPlugin.prototype, 'listDataSets')
-      .mockImplementation(async (pageSize: number, paginationToken: string | undefined) => {
+      .mockImplementation(async (_pageSize: number, _paginationToken: string | undefined) => {
         return {
           data: [
             {
@@ -252,7 +252,7 @@ describe('DataSetService', () => {
     jest.spyOn(DdbDataSetMetadataPlugin.prototype, 'removeDataSet').mockImplementation(async () => {});
     jest
       .spyOn(DdbDataSetMetadataPlugin.prototype, 'getDataSetEndPointDetails')
-      .mockImplementation(async (dataSetId: string, endpointId: string) => {
+      .mockImplementation(async (_dataSetId: string, endpointId: string) => {
         if (endpointId === mockNoRolesEndpointId) {
           return {
             id: mockExistingEndpointId,
@@ -325,7 +325,7 @@ describe('DataSetService', () => {
     });
     jest
       .spyOn(DdbDataSetMetadataPlugin.prototype, 'listStorageLocations')
-      .mockImplementation(async (pageSize: number, paginationToken: string | undefined) => {
+      .mockImplementation(async (_pageSize: number, _paginationToken: string | undefined) => {
         return {
           data: [
             {

--- a/workbench-core/datasets/src/ddbDataSetMetadataPlugin.ts
+++ b/workbench-core/datasets/src/ddbDataSetMetadataPlugin.ts
@@ -98,13 +98,13 @@ export class DdbDataSetMetadataPlugin implements DataSetMetadataPlugin {
     return DataSetParser.parse(response.Item);
   }
 
-  public async listDataSetObjects(dataSetName: string): Promise<string[]> {
+  public async listDataSetObjects(_dataSetName: string): Promise<string[]> {
     throw new Error('Method not implemented.');
   }
 
   public async getDataSetObjectMetadata(
-    dataSetName: string,
-    objectName: string
+    _dataSetName: string,
+    _objectName: string
   ): Promise<Record<string, string>> {
     throw new Error('Method not implemented.');
   }

--- a/workbench-core/datasets/src/s3DataSetStoragePlugin.test.ts
+++ b/workbench-core/datasets/src/s3DataSetStoragePlugin.test.ts
@@ -64,7 +64,7 @@ describe('S3DataSetStoragePlugin', () => {
     itProp(
       'class is intialized given the specified parameters',
       [fc.string(), fc.string(), fc.string()],
-      (accessKeyId: string, secretAccessKey, kmsKeyArn) => {
+      (accessKeyId: string, secretAccessKey, _kmsKeyArn) => {
         const randomAwsCreds = {
           accessKeyId: accessKeyId,
           secretAccessKey: secretAccessKey

--- a/workbench-core/datasets/src/s3DataSetStoragePlugin.ts
+++ b/workbench-core/datasets/src/s3DataSetStoragePlugin.ts
@@ -145,7 +145,7 @@ export class S3DataSetStoragePlugin implements DataSetsStoragePlugin {
   }
 
   public async addRoleToExternalEndpoint(
-    name: string,
+    _name: string,
     path: string,
     externalEndpointName: string,
     externalRoleName: string,
@@ -165,9 +165,9 @@ export class S3DataSetStoragePlugin implements DataSetsStoragePlugin {
   }
 
   public async removeRoleFromExternalEndpoint(
-    name: string,
-    externalEndpointName: string,
-    externalRoleArn: string
+    _name: string,
+    _externalEndpointName: string,
+    _externalRoleArn: string
   ): Promise<void> {
     throw new Error('Method not implemented.');
   }
@@ -185,9 +185,9 @@ export class S3DataSetStoragePlugin implements DataSetsStoragePlugin {
   }
 
   public async createPresignedMultiPartUploadUrls(
-    dataSetName: string,
-    numberOfParts: number,
-    timeToLiveSeconds: number
+    _dataSetName: string,
+    _numberOfParts: number,
+    _timeToLiveSeconds: number
   ): Promise<string[]> {
     throw new Error('Method not implemented.');
   }

--- a/workbench-core/environments-ui/src/components/EnvTypeCards.tsx
+++ b/workbench-core/environments-ui/src/components/EnvTypeCards.tsx
@@ -59,7 +59,7 @@ export default function EnvTypeCards(props: EnvTypesProps): JSX.Element {
       loading={props.isLoading}
       loadingText="Loading Compute Platforms"
       onSelectionChange={({ detail }) => {
-        setSelectedItems((prevState) => detail.selectedItems);
+        setSelectedItems((_prevState) => detail.selectedItems);
         props.onSelect(detail);
       }}
       selectedItems={selectedItems}

--- a/workbench-core/eslint-custom/src/custom-eslint.ts
+++ b/workbench-core/eslint-custom/src/custom-eslint.ts
@@ -8,16 +8,7 @@ import { importConvention } from './rules/import-convention';
 import { namingConvention } from './rules/naming-convention';
 
 const rules: any = Object.assign({}, namingConvention.rules, importConvention.rules, {
-  '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
-  '@typescript-eslint/naming-convention': [
-    'error',
-    {
-      selector: 'parameter',
-      modifiers: ['unused'],
-      format: ['strictCamelCase'],
-      leadingUnderscore: 'allow'
-    }
-  ]
+  '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }]
 });
 
 export const customESLint: any = {

--- a/workbench-core/eslint-custom/src/custom-eslint.ts
+++ b/workbench-core/eslint-custom/src/custom-eslint.ts
@@ -7,7 +7,18 @@
 import { importConvention } from './rules/import-convention';
 import { namingConvention } from './rules/naming-convention';
 
-const rules: any = Object.assign({}, namingConvention.rules, importConvention.rules);
+const rules: any = Object.assign({}, namingConvention.rules, importConvention.rules, {
+  '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+  '@typescript-eslint/naming-convention': [
+    'error',
+    {
+      selector: 'parameter',
+      modifiers: ['unused'],
+      format: ['strictCamelCase'],
+      leadingUnderscore: 'allow'
+    }
+  ]
+});
 
 export const customESLint: any = {
   plugins: ['security', 'import'],
@@ -18,7 +29,7 @@ export const customESLint: any = {
     'plugin:import/recommended',
     'plugin:import/typescript'
   ],
-  rules: rules,
+  rules,
   settings: {
     'import/parsers': {
       '@typescript-eslint/parser': ['.ts', '.tsx']

--- a/workbench-core/eslint-custom/src/rules/naming-convention.ts
+++ b/workbench-core/eslint-custom/src/rules/naming-convention.ts
@@ -34,6 +34,7 @@ export const namingConvention: any = {
           selectors: ['parameter'],
 
           format: ['camelCase'],
+          leadingUnderscore: 'allow',
 
           filter: {
             regex: [

--- a/workbench-core/example/infrastructure/.eslintignore
+++ b/workbench-core/example/infrastructure/.eslintignore
@@ -7,3 +7,5 @@ build
 buildLambda.js
 generateCognitoTokens.js
 jest.config.js
+cypress
+cypress.config.ts

--- a/workbench-core/example/infrastructure/integration-tests/support/resources/authentication/authentication.ts
+++ b/workbench-core/example/infrastructure/integration-tests/support/resources/authentication/authentication.ts
@@ -20,7 +20,7 @@ export default class Authentication extends CollectionResource {
     this._csrfToken = csrf.create(this._csrfSecret);
   }
 
-  public async create(body: unknown = {}, applyDefault: boolean = true): Promise<AxiosResponse> {
+  public async create(_body: unknown = {}, _applyDefault: boolean = true): Promise<AxiosResponse> {
     throw new Error('Authentication should not be creating new resources.');
   }
 

--- a/workbench-core/logging/src/loggingService.test.ts
+++ b/workbench-core/logging/src/loggingService.test.ts
@@ -51,9 +51,9 @@ describe('LoggingService tests', () => {
     it('should use options.loggingPlugin when defined', () => {
       class FakePlugin implements LoggingPlugin {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public log(level: LogLevel, message: any, ...meta: any[]): void {}
-        public setMaxLogLevel(level: LogLevel): void {}
-        public setDefaultMetadata(metadata: LogMessageObject): void {}
+        public log(_level: LogLevel, _message: any, ..._meta: any[]): void {}
+        public setMaxLogLevel(_level: LogLevel): void {}
+        public setDefaultMetadata(_metadata: LogMessageObject): void {}
       }
 
       const logger = new LoggingService({ loggingPlugin: new FakePlugin() });

--- a/workbench-core/swb-common-ui/src/context/NotificationContext.tsx
+++ b/workbench-core/swb-common-ui/src/context/NotificationContext.tsx
@@ -18,8 +18,8 @@ export interface NotificationProps {
 
 const NotificationsContext: React.Context<NotificationProps> = React.createContext({
   notifications: {} as Notifications,
-  displayNotification: (id: string, notification: FlashbarProps.MessageDefinition) => {},
-  closeNotification: (id: string) => {}
+  displayNotification: (_id: string, _notification: FlashbarProps.MessageDefinition) => {},
+  closeNotification: (_id: string) => {}
 });
 
 export function NotificationsProvider({ children }: { children: React.ReactNode }): JSX.Element {


### PR DESCRIPTION
Issue #, if available:

Description of changes:

ESLint update to allow unused method parameters to have a leading underscore

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.