### PR TITLE
chore(zod): filter between val1<=val2

### DIFF
--- a/common/changes/@aws/workbench-core-base/janeyu-zodFilterBetween_2023-05-12-17-14.json
+++ b/common/changes/@aws/workbench-core-base/janeyu-zodFilterBetween_2023-05-12-17-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-base",
+      "comment": "enforce between val1 <= val2",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-base"
+}

--- a/solutions/swb-reference/integration-tests/tests/isolated/environments/list.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/environments/list.test.ts
@@ -6,7 +6,8 @@ import {
   lengthValidationMessage,
   urlFilterMaxLength,
   JSONValue,
-  nonEmptyMessage
+  nonEmptyMessage,
+  betweenFilterMessage
 } from '@aws/workbench-core-base';
 import ClientSession from '../../../support/clientSession';
 import { PaabHelper } from '../../../support/complex/paabHelper';
@@ -104,7 +105,7 @@ describe('list environments', () => {
       expect(Array.isArray(response.data)).toBe(true);
     });
 
-    test('list project environments with filter on empty name', async () => {
+    test('list environments with filter on empty name', async () => {
       try {
         await itAdminSession.resources.environments.get({ filter: { name: { eq: '' } } });
       } catch (e) {
@@ -113,6 +114,29 @@ describe('list environments', () => {
           new HttpError(400, {
             error: 'Bad Request',
             message: `filter.name.eq: ${nonEmptyMessage}`
+          })
+        );
+      }
+    });
+
+    test('list environments with filter createdAt between value1 > value2', async () => {
+      try {
+        await itAdminSession.resources.environments.get({
+          filter: {
+            createdAt: {
+              between: {
+                value1: '2023-05-14T07:23:39.311Z',
+                value2: '2023-05-11T07:23:39.311Z'
+              }
+            }
+          }
+        });
+      } catch (e) {
+        checkHttpError(
+          e,
+          new HttpError(400, {
+            error: 'Bad Request',
+            message: `filter.createdAt.between: ${betweenFilterMessage}`
           })
         );
       }

--- a/solutions/swb-reference/integration-tests/tests/isolated/projects/list.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/projects/list.test.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { nonEmptyMessage } from '@aws/workbench-core-base';
+import { nonEmptyMessage, betweenFilterMessage } from '@aws/workbench-core-base';
 import ClientSession from '../../../support/clientSession';
 import { PaabHelper } from '../../../support/complex/paabHelper';
 import HttpError from '../../../support/utils/HttpError';
@@ -43,6 +43,34 @@ describe('List Project negative tests', () => {
             })
           );
         }
+      });
+    });
+
+    describe('with createdAt', () => {
+      beforeEach(async () => {});
+      describe('with value1 > value2', () => {
+        test('it throws 400 error', async () => {
+          try {
+            await adminSession.resources.projects.get({
+              filter: {
+                createdAt: {
+                  between: {
+                    value1: '2023-05-14T07:23:39.311Z',
+                    value2: '2023-05-11T07:23:39.311Z'
+                  }
+                }
+              }
+            });
+          } catch (e) {
+            checkHttpError(
+              e,
+              new HttpError(400, {
+                error: 'Bad Request',
+                message: `filter.createdAt.between: ${betweenFilterMessage}`
+              })
+            );
+          }
+        });
       });
     });
   });

--- a/workbench-core/base/src/index.ts
+++ b/workbench-core/base/src/index.ts
@@ -61,7 +61,8 @@ import {
   swbNameMessage,
   nonHTMLMessage,
   swbDescriptionMaxLength,
-  lengthValidationMessage
+  lengthValidationMessage,
+  betweenFilterMessage
 } from './utilities/textUtil';
 import { getPaginationParser, validateAndParse, z } from './utilities/validatorHelper';
 
@@ -125,5 +126,6 @@ export {
   swbNameMessage,
   nonHTMLMessage,
   swbDescriptionMaxLength,
-  lengthValidationMessage
+  lengthValidationMessage,
+  betweenFilterMessage
 };

--- a/workbench-core/base/src/interfaces/queryStringParamFilter.ts
+++ b/workbench-core/base/src/interfaces/queryStringParamFilter.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { lengthValidationMessage, urlFilterMaxLength } from '../utilities/textUtil';
+import { lengthValidationMessage, urlFilterMaxLength, betweenFilterMessage } from '../utilities/textUtil';
 import { z } from '../utilities/validatorHelper';
 
 /************
@@ -26,6 +26,9 @@ export const QueryStringParamFilterParser = z
       .object({
         value1: parameterFilterParser.required(),
         value2: parameterFilterParser.required()
+      })
+      .refine((data) => data.value1 <= data.value2, {
+        message: betweenFilterMessage
       })
       .optional(),
     begins: parameterFilterParser.optionalNonEmpty()

--- a/workbench-core/base/src/utilities/textUtil.ts
+++ b/workbench-core/base/src/utilities/textUtil.ts
@@ -34,6 +34,7 @@ const invalidIdMessage: string = 'Invalid ID';
 const invalidEmailMessage: string = 'Invalid Email';
 const requiredMessage: string = 'Required';
 const urlFilterMaxLength: number = 128;
+const betweenFilterMessage: string = 'value1 must be less than or equal to value2';
 
 const groupIDRegExpAsString: string = '\\S{1,128}';
 
@@ -169,6 +170,7 @@ export {
   invalidEmailMessage,
   requiredMessage,
   urlFilterMaxLength,
+  betweenFilterMessage,
   lengthValidationMessage,
   sshKeyIdRegex,
   userIdRegex


### PR DESCRIPTION
Issue #, if available:P88136656

Description of changes:
* Filter parser should return 4xx error when given filter between val1 <= val2
* All List APIs (list env & list project) have been verified to return 4xx errors instead of 5xx error when given a start date that is later than end date for createdAt timestamp 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.