### PR TITLE
chore(user-management): add cognito group limit 25

### DIFF
--- a/common/changes/@aws/workbench-core-user-management/janeyu-cognitoLimit_2023-05-12-23-46.json
+++ b/common/changes/@aws/workbench-core-user-management/janeyu-cognitoLimit_2023-05-12-23-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-user-management",
+      "comment": "add cognito group limit",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-user-management"
+}

--- a/workbench-core/user-management/src/errors/errors.test.ts
+++ b/workbench-core/user-management/src/errors/errors.test.ts
@@ -14,12 +14,14 @@ import {
   isTooManyRequestsError,
   isUserAlreadyExistsError,
   isUserNotFoundError,
+  isUserRolesExceedLimitError,
   PluginConfigurationError,
   RoleAlreadyExistsError,
   RoleNotFoundError,
   TooManyRequestsError,
   UserAlreadyExistsError,
-  UserNotFoundError
+  UserNotFoundError,
+  UserRolesExceedLimitError
 } from '../';
 
 describe('custom error tests', () => {
@@ -130,6 +132,20 @@ describe('custom error tests', () => {
 
     it('should be an instance of Error', () => {
       const error = new TooManyRequestsError();
+
+      expect(error instanceof Error).toBe(true);
+    });
+  });
+
+  describe('UserRolesExceedLimitError tests', () => {
+    it('should be an instance of itself', () => {
+      const error = new UserRolesExceedLimitError();
+
+      expect(isUserRolesExceedLimitError(error)).toBe(true);
+    });
+
+    it('should be an instance of Error', () => {
+      const error = new UserRolesExceedLimitError();
 
       expect(error instanceof Error).toBe(true);
     });

--- a/workbench-core/user-management/src/errors/userRolesExceedLimitError.ts
+++ b/workbench-core/user-management/src/errors/userRolesExceedLimitError.ts
@@ -1,0 +1,24 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+export class UserRolesExceedLimitError extends Error {
+  public readonly isUserRolesExceedLimitError: boolean;
+
+  public constructor(message?: string) {
+    super(message);
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, UserRolesExceedLimitError);
+    }
+
+    this.name = this.constructor.name;
+    this.isUserRolesExceedLimitError = true;
+  }
+}
+
+export function isUserRolesExceedLimitError(error: unknown): error is UserRolesExceedLimitError {
+  return Boolean(error) && (error as UserRolesExceedLimitError).isUserRolesExceedLimitError === true;
+}

--- a/workbench-core/user-management/src/index.ts
+++ b/workbench-core/user-management/src/index.ts
@@ -13,5 +13,6 @@ export { RoleNotFoundError, isRoleNotFoundError } from './errors/roleNotFoundErr
 export { TooManyRequestsError, isTooManyRequestsError } from './errors/tooManyRequestsError';
 export { UserAlreadyExistsError, isUserAlreadyExistsError } from './errors/userAlreadyExistsError';
 export { UserNotFoundError, isUserNotFoundError } from './errors/userNotFoundError';
+export { UserRolesExceedLimitError, isUserRolesExceedLimitError } from './errors/userRolesExceedLimitError';
 export { CognitoUserManagementPlugin } from './plugins/cognitoUserManagementPlugin';
 export { UserManagementService } from './userManagementService';


### PR DESCRIPTION
Issue #, if available: P88136850

Description of changes:

* add user group limit 25 to cognitoUserManagement
* update unit test

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?
* [X] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.