### PR TITLE
fix: unblock pipeline with longer ttl on temp creds and no account cleanup

### DIFF
--- a/solutions/swb-reference/integration-tests/support/resources/accounts/account.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/accounts/account.ts
@@ -19,10 +19,11 @@ export default class Account extends Resource {
     const existingAccounts = await accountHelper.listOnboardedAccounts();
     const resource = _.find(existingAccounts, { awsAccountId: settings.get('hostAwsAccountId') });
 
-    if (resource) {
-      const { id, awsAccountId } = resource;
-      await accountHelper.deOnboardAccount(awsAccountId);
-      await accountHelper.deleteDdbRecords(id, awsAccountId);
-    }
+    console.log(resource);
+    // if (resource) {
+    //   const { id, awsAccountId } = resource;
+    //   await accountHelper.deOnboardAccount(awsAccountId);
+    //   await accountHelper.deleteDdbRecords(id, awsAccountId);
+    // }
   }
 }

--- a/solutions/swb-reference/src/backendAPI.ts
+++ b/solutions/swb-reference/src/backendAPI.ts
@@ -68,7 +68,8 @@ const cognitoUserManagementPlugin: CognitoUserManagementPlugin = new CognitoUser
   process.env.USER_POOL_ID!,
   aws,
   {
-    ddbService: dynamicAuthAws.helpers.ddb
+    ddbService: dynamicAuthAws.helpers.ddb,
+    ttl: 60 * 60
   }
 );
 const userManagementService: UserManagementService = new UserManagementService(cognitoUserManagementPlugin);


### PR DESCRIPTION
Issue #, if available:

Description of changes:
comment out the cleanup steps that are destroying functionality in deployments (we will revisit a better way to do the test and cleanup later)
make ttl for temp project creds 60 min in line with access token validity

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.