### PR TITLE
chore(viperlight): replace with authorized creds

### DIFF
--- a/.viperlightignore
+++ b/.viperlightignore
@@ -13,11 +13,9 @@ lib
 .*/NOTICE
 
 # Test files
-# email: 'sample.user@example.com' is not real email
-#solutions/example-ui-app/src/models/User.ts:19
 # Fake emails for UserManagementService integ tests
-#workbench-core/example/infrastructure/integration-tests/tests/users/activateDeactivateUser.test.ts:30
-#workbench-core/example/infrastructure/integration-tests/tests/users/createUser.test.ts:23
+workbench-core/example/infrastructure/integration-tests/tests/users/activateDeactivateUser.test.ts:30
+workbench-core/example/infrastructure/integration-tests/tests/users/createUser.test.ts:23
 workbench-core/example/infrastructure/integration-tests/tests/users/updateUser.test.ts:31
 workbench-core/example/infrastructure/integration-tests/tests/users/listUsers.test.ts:31
 workbench-core/example/infrastructure/integration-tests/tests/users/listUsers.test.ts:37
@@ -40,17 +38,9 @@ workbench-core/example/infrastructure/scripts/setupCognito.sh:44
 solutions/swb-reference/integration-tests/tests/isolated/users/activateDeactivateUser.test.ts:31
 solutions/swb-reference/integration-tests/tests/isolated/users/createUser.test.ts:24
 solutions/swb-reference/integration-tests/tests/isolated/users/updateUser.test.ts:31
-solutions/swb-reference/integration-tests/tests/multiStep/userApi.test.ts:29
-solutions/swb-reference/integration-tests/tests/multiStep/userApi.test.ts:82
 
 # Fake emails for user to project integ tests
 solutions/swb-reference/integration-tests/tests/isolated/projects/assignUserToProject.test.ts:91
 solutions/swb-reference/integration-tests/tests/multiStep/user.test.ts:38
 solutions/swb-reference/integration-tests/tests/multiStep/userProject.test.ts:48
 solutions/swb-reference/integration-tests/tests/multiStep/userProject.test.ts:86
-
-# Fake emails used: setupIntegTestEnv.sh script
-solutions/swb-reference/scripts/setupIntegTestEnv.sh:66
-solutions/swb-reference/scripts/setupIntegTestEnv.sh:207
-solutions/swb-reference/scripts/setupIntegTestEnv.sh:225
-solutions/swb-reference/scripts/setupIntegTestEnv.sh:243

--- a/.viperlightignore
+++ b/.viperlightignore
@@ -13,21 +13,11 @@ lib
 .*/NOTICE
 
 # Test files
-#SecretAccessKey=\'sampleSecretAccessKey\' is not real secret
-solutions/swb-reference/src/environment/sagemakerNotebook/sagemakerNotebookEnvironmentConnectionService.test.ts:26
-# SecretAccessKey: 'sampleSecretAccessKey' is not real secret
-workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:190
-# SecretAccessKey: 'sampleSecretAccessKey' is not real secret
-workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:250
-# SecretAccessKey: 'sampleSecretAccessKey' is not real secret
-workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:293
 # email: 'sample.user@example.com' is not real email
-solutions/example-ui-app/src/models/User.ts:19
-# "email": "hello@cypress.io" is not real email
-solutions/swb-ui/ui/end-to-end-tests/cypress/fixtures/example.json:3
+#solutions/example-ui-app/src/models/User.ts:19
 # Fake emails for UserManagementService integ tests
-workbench-core/example/infrastructure/integration-tests/tests/users/activateDeactivateUser.test.ts:30
-workbench-core/example/infrastructure/integration-tests/tests/users/createUser.test.ts:23
+#workbench-core/example/infrastructure/integration-tests/tests/users/activateDeactivateUser.test.ts:30
+#workbench-core/example/infrastructure/integration-tests/tests/users/createUser.test.ts:23
 workbench-core/example/infrastructure/integration-tests/tests/users/updateUser.test.ts:31
 workbench-core/example/infrastructure/integration-tests/tests/users/listUsers.test.ts:31
 workbench-core/example/infrastructure/integration-tests/tests/users/listUsers.test.ts:37
@@ -52,12 +42,7 @@ solutions/swb-reference/integration-tests/tests/isolated/users/createUser.test.t
 solutions/swb-reference/integration-tests/tests/isolated/users/updateUser.test.ts:31
 solutions/swb-reference/integration-tests/tests/multiStep/userApi.test.ts:29
 solutions/swb-reference/integration-tests/tests/multiStep/userApi.test.ts:82
-# Fake account ID used for workbenchAppRegistry tests
-workbench-core/infrastructure/src/workbenchAppRegistry.test.ts:79
-workbench-core/infrastructure/src/workbenchAppRegistry.test.ts:91
-workbench-core/infrastructure/src/workbenchAppRegistry.test.ts:109
-workbench-core/infrastructure/src/workbenchAppRegistry.test.ts:136
-workbench-core/infrastructure/src/workbenchAppRegistry.test.ts:161
+
 # Fake emails for user to project integ tests
 solutions/swb-reference/integration-tests/tests/isolated/projects/assignUserToProject.test.ts:91
 solutions/swb-reference/integration-tests/tests/multiStep/user.test.ts:38

--- a/.viperlightignore
+++ b/.viperlightignore
@@ -13,6 +13,8 @@ lib
 .*/NOTICE
 
 # Test files
+# Note that emails need to end with @simulator.amazonses.com in order to work against Cognito
+# Other test fake data must come from https://alpha.www.docs.aws.a2z.com/awsstyleguide/latest/styleguide/safenames.html
 # Fake emails for UserManagementService integ tests
 workbench-core/example/infrastructure/integration-tests/tests/users/activateDeactivateUser.test.ts:30
 workbench-core/example/infrastructure/integration-tests/tests/users/createUser.test.ts:23

--- a/common/changes/@aws/workbench-core-environments/janeyu-viperignore_2023-05-18-19-33.json
+++ b/common/changes/@aws/workbench-core-environments/janeyu-viperignore_2023-05-18-19-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-environments",
+      "comment": "replace with authorized fictitious data",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-environments"
+}

--- a/common/changes/@aws/workbench-core-infrastructure/janeyu-viperignore_2023-05-18-19-33.json
+++ b/common/changes/@aws/workbench-core-infrastructure/janeyu-viperignore_2023-05-18-19-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-infrastructure",
+      "comment": "replace with authorized fictitious data",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-infrastructure"
+}

--- a/solutions/swb-reference/scripts/setupIntegTestEnv.sh
+++ b/solutions/swb-reference/scripts/setupIntegTestEnv.sh
@@ -63,7 +63,7 @@ Usage: `basename $0`
     -k [EncryptionKeyArn FROM HOSTING ACCOUNT DEPLOYMENT]
 
 Example:
-    `basename $0` -m '<email@example.com>' -p 'xxxxxxxxxxx' -s 'dev' -r 'va' -i 'XXXXXXXXXXXX' -e '<externalId>' -k 'arn:aws:kms:XXXXXXXX:XXXXXXXXXXXX:key/XXXXXXXXXXXXXXXXXXXXX'
+    `basename $0` -m '<johndoe@example.com>' -p 'xxxxxxxxxxx' -s 'dev' -r 'va' -i 'XXXXXXXXXXXX' -e '<externalId>' -k 'arn:aws:kms:XXXXXXXX:XXXXXXXXXXXX:key/XXXXXXXXXXXXXXXXXXXXX'
           ${NC}"
 }
 
@@ -204,7 +204,7 @@ function run() {
 
     echo -e "${CYAN}\nCreate ProjectAdmin1 user"
     echo -e "-------------------------"
-    PA1_EMAIL="pa1_test@fakeemail.com"
+    PA1_EMAIL="johndoe@example.com"
     $(curl --location --request POST "https://$swbDomainName/api/users" --header "Cookie: access_token=$accessToken;_csrf=$csrfCookie" --header "csrf-token: $csrfToken" --header 'Content-Type: application/json' \
     --data "{
         \"firstName\": \"PA1F\",
@@ -222,7 +222,7 @@ function run() {
 
     echo -e "${BLUE}\nCreate ProjectAdmin2 user"
     echo -e "-------------------------"
-    PA2_EMAIL="pa2_test@fakeemail.com"
+    PA2_EMAIL="janedoe@example.com"
     $(curl --location --request POST "https://$swbDomainName/api/users" --header "Cookie: access_token=$accessToken;_csrf=$csrfCookie" --header "csrf-token: $csrfToken" --header 'Content-Type: application/json' \
     --data "{
         \"firstName\": \"PA2F\",
@@ -240,7 +240,7 @@ function run() {
 
     echo -e "${CYAN}\nCreate Researcher1 user"
     echo -e "-------------------------"
-    RE1_EMAIL="re1_test@fakeemail.com"
+    RE1_EMAIL="johnstiles@example.com"
     $(curl --location --request POST "https://$swbDomainName/api/users" --header "Cookie: access_token=$accessToken;_csrf=$csrfCookie" --header "csrf-token: $csrfToken" --header 'Content-Type: application/json' \
     --data "{
         \"firstName\": \"RE1F\",

--- a/solutions/swb-reference/src/environment/sagemakerNotebook/sagemakerNotebookEnvironmentConnectionService.test.ts
+++ b/solutions/swb-reference/src/environment/sagemakerNotebook/sagemakerNotebookEnvironmentConnectionService.test.ts
@@ -23,7 +23,7 @@ describe('SagemakerNotebookEnvironmentConnectionService', () => {
     iamMock.on(AssumeRoleCommand).resolvesOnce({
       Credentials: {
         AccessKeyId: 'sampleAccessKey',
-        SecretAccessKey: 'sampleSecretAccessKey',
+        SecretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
         SessionToken: 'sampleSessionToken',
         Expiration: new Date()
       }

--- a/workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts
+++ b/workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts
@@ -187,7 +187,7 @@ describe('EnvironmentLifecycleHelper', () => {
     stsMock.on(AssumeRoleCommand).resolves({
       Credentials: {
         AccessKeyId: 'sampleAccessKey',
-        SecretAccessKey: 'sampleSecretAccessKey',
+        SecretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
         SessionToken: 'blah',
         Expiration: undefined
       }
@@ -247,7 +247,7 @@ describe('EnvironmentLifecycleHelper', () => {
     stsMock.on(AssumeRoleCommand).resolves({
       Credentials: {
         AccessKeyId: 'sampleAccessKey',
-        SecretAccessKey: 'sampleSecretAccessKey',
+        SecretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
         SessionToken: 'blah',
         Expiration: undefined
       }
@@ -290,7 +290,7 @@ describe('EnvironmentLifecycleHelper', () => {
     stsMock.on(AssumeRoleCommand).resolves({
       Credentials: {
         AccessKeyId: 'sampleAccessKey',
-        SecretAccessKey: 'sampleSecretAccessKey',
+        SecretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
         SessionToken: 'blah',
         Expiration: undefined
       }

--- a/workbench-core/infrastructure/src/workbenchAppRegistry.test.ts
+++ b/workbench-core/infrastructure/src/workbenchAppRegistry.test.ts
@@ -76,7 +76,7 @@ describe('WorkbenchAppRegistry Test', () => {
       attributeGroupName: 'TestApp-Metadata',
       applicationType: 'Test',
       appRegistryApplicationName: 'TestApp',
-      accountIds: ['012345678901']
+      accountIds: ['111122223333']
     });
 
     const template = Template.fromStack(stack);
@@ -88,7 +88,7 @@ describe('WorkbenchAppRegistry Test', () => {
       PermissionArns: [
         'arn:aws:ram::aws:permission/AWSRAMPermissionServiceCatalogAppRegistryAttributeGroupAllowAssociation'
       ],
-      Principals: ['012345678901'],
+      Principals: ['111122223333'],
       ResourceArns: [
         {
           'Fn::GetAtt': ['TestStackAttributeGroup7F76BDF8', 'Arn']
@@ -106,7 +106,7 @@ describe('WorkbenchAppRegistry Test', () => {
       attributeGroupName: 'TestApp-Metadata',
       applicationType: 'Test',
       appRegistryApplicationName: 'TestApp',
-      accountIds: ['012345678901'],
+      accountIds: ['111122223333'],
       destroy: true
     });
 
@@ -133,7 +133,7 @@ describe('WorkbenchAppRegistry Test', () => {
       attributeGroupName: 'TestApp-Metadata',
       applicationType: 'Test',
       appRegistryApplicationName: 'TestApp',
-      accountIds: ['012345678901'],
+      accountIds: ['111122223333'],
       appInsights: true
     });
 
@@ -158,7 +158,7 @@ describe('WorkbenchAppRegistry Test', () => {
       attributeGroupName: 'TestApp-Metadata',
       applicationType: 'Test',
       appRegistryApplicationName: 'TestApp',
-      accountIds: ['012345678901']
+      accountIds: ['111122223333']
     });
 
     testAppRegistry.applyAppRegistryToStacks([testStack2], false);


### PR DESCRIPTION
Issue #, if available: GALI-2462

Description of changes:

fake test data has to come from the list of authorized fictitious data: https://alpha.www.docs.aws.a2z.com/awsstyleguide/latest/styleguide/safenames.html, which .viperlight automatically ignores

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.