### PR TITLE
fix(account-status): working account status update for byon

### DIFF
--- a/common/changes/@aws/workbench-core-accounts/thingut-account-onboarding-status_2023-05-18-19-38.json
+++ b/common/changes/@aws/workbench-core-accounts/thingut-account-onboarding-status_2023-05-18-19-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-accounts",
+      "comment": "Update account handler to check onboard-account-byon.cfn.yml, onboard-account-tgw.cfn.yml, and onboard-account.cfn.yml so if users have a hosting account that isn't onboard-account.cfn.yml, their account status is correct.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-accounts"
+}

--- a/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
+++ b/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
@@ -396,13 +396,12 @@ export default class HostingAccountLifecycleService {
         return output.OutputKey === 'EncryptionKeyArn';
       })!.OutputValue;
 
-      if (
-        expectedTemplates
-          .map((template) => {
-            return removeCommentsAndSpaces(template);
-          })
-          .includes(removeCommentsAndSpaces(actualTemplate))
-      ) {
+      const expectedTemplatesWithoutCommentsAndSpaces = expectedTemplates.map((template) => {
+        return removeCommentsAndSpaces(template);
+      });
+
+      // If the actual template matches one of the expected template then the account is current
+      if (expectedTemplatesWithoutCommentsAndSpaces.includes(removeCommentsAndSpaces(actualTemplate))) {
         await this._writeAccountStatusToDDB({
           ddbAccountId,
           status: 'CURRENT',

--- a/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
+++ b/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
@@ -346,7 +346,6 @@ export default class HostingAccountLifecycleService {
     hostingAccountStackName: string
   ): Promise<void> {
     // Check if hosting account stack has the latest CFN template
-    console.log('s3ArtifactBucketName', s3ArtifactBucketName);
     const onboardAccountS3Response = await this._aws.clients.s3.getObject({
       Bucket: s3ArtifactBucketName,
       Key: 'onboard-account.cfn.yaml'

--- a/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
+++ b/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
@@ -345,7 +345,6 @@ export default class HostingAccountLifecycleService {
     hostingAccountAwsService: AwsService,
     hostingAccountStackName: string
   ): Promise<void> {
-    console.log('Check and update hosting account status');
     // Check if hosting account stack has the latest CFN template
     console.log('s3ArtifactBucketName', s3ArtifactBucketName);
     const onboardAccountS3Response = await this._aws.clients.s3.getObject({

--- a/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
+++ b/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
@@ -347,6 +347,7 @@ export default class HostingAccountLifecycleService {
   ): Promise<void> {
     console.log('Check and update hosting account status');
     // Check if hosting account stack has the latest CFN template
+    console.log('s3ArtifactBucketName', s3ArtifactBucketName);
     const onboardAccountS3Response = await this._aws.clients.s3.getObject({
       Bucket: s3ArtifactBucketName,
       Key: 'onboard-account.cfn.yaml'


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Update account handler to check `onboard-account-byon.cfn.yml`, `onboard-account-tgw.cfn.yml`, and `onboard-account.cfn.yml` so if users have a hosting account that isn't `onboard-account.cfn.yml`, their account status is correct.

Testing
* This works with `onboard-account.cfn.yml` and `onboard-account-byon.cfn.yml`. I didn't test it with `onboard-account-tgw.cfn.yml`, but it follows the same logic as BYON and should work as expected. 


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

*  [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.