### PR TITLE
fix: node v16 required for Cloud9 installation

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
   "rushVersion": "5.83.1",
   "pnpmVersion": "7.13.0",
-  "nodeSupportedVersionRange": ">=18.0.0 <19.0.0",
+  "nodeSupportedVersionRange": ">=16.0.0 <19.0.0",
   "ensureConsistentVersions": true,
   "projectFolderMaxDepth": 3,
   "approvedPackagesPolicy": {


### PR DESCRIPTION
Issue #, if available:
RSW installation on Cloud9 requires node v16.

Description of changes:
Changing rush config to accept node v16

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.