### PR TITLE
test(account): redo account multistep integ test

### DIFF
--- a/common/changes/@aws/workbench-core-accounts/maghirardelli-fix-account-test_2023-05-26-17-23.json
+++ b/common/changes/@aws/workbench-core-accounts/maghirardelli-fix-account-test_2023-05-26-17-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-accounts",
+      "comment": "delete accountService.delete as it is never used",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-accounts"
+}

--- a/solutions/swb-reference/README.md
+++ b/solutions/swb-reference/README.md
@@ -631,14 +631,6 @@ Note: `setupIntegTestEnv.sh` script also creates the `Config file for integratio
     1. Choose the Project that integration test will use as default when creating any Environment and testing project functionality and copy the `id` value from the response.
     1. In `./integration-tests/config` directory assign `id` to `projectId` in `<STAGE>.yaml` file 
 
-1. Follow these steps to assign a value to `terminatedEnvId` parameter in `./integration-tests/config/<STAGE>.yaml` file
-    1. Follow instructions in [Launch Sagemaker Notebook Environment](#launch-sagemaker-notebook-instance) to create a new Sagemaker environment and wait for COMPLETED status.
-    1. Copy the `id` value from the response
-    1. Use the `id` of the new environment to [Stop the environment](#stop-an-environment) and wait for STOPPED status.
-    1. Use the `id` of the new environment to [Terminate the environment](#terminate-the-environment).
-    1. Use new instance information to [Terminate](#terminate-the-environment)
-    1. In `./integration-tests/config` directory assign the `id` of the new environment to the `terminatedEnvId` in `<STAGE>.yaml` file  
-
 1. Follow these steps to assign a value to `rootUserNameParamStorePath` parameter in `./integration-tests/config/<STAGE>.yaml` file
     1. Uncomment `rootUserNameParamStorePath` and provide a name for a SSM parameter that will contain the main account user's email address, e.g. `/swb/<STAGE>/rootUser/email`.
     1. Follow instructions to [create a SSM Parameter](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-create-console.html) in your main account and set the name as the assigned value in `rootUserNameParamStorePath` and the value as the main account user's email address.
@@ -677,21 +669,9 @@ Note: `setupIntegTestEnv.sh` script also creates the `Config file for integratio
     1. Follow instructions in [Reset User Password Step](#reset-user-password) to assign a password to the Researcher assigned to `researcher1UserNameParamStorePath`.
     1. Follow instructions to [create a SSM Parameter](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-create-console.html) in your main account and set the name as the assigned value in `researcher1PasswordParamStorePath` and the value as the Researcher's new password.
 
-1. Follow these steps to assign a value to `hostAwsAccountIdParamStorePath` parameter in `./integration-tests/config/<STAGE>.yaml` file
-    1. Uncomment `researcher1PasswordParamStorePath` and provide a name for a SSM parameter that will contain the 12 Digit Hosting Account Id, e.g. `/swb/<STAGE>/accountsTest/awsAccountId`.
-    1. Follow instructions to [create a SSM Parameter](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-create-console.html) in your main account and set the name as the assigned value in `hostAwsAccountIdParamStorePath` and the value as the the 12 Digit Hosting Account Id.
-
-1. Follow these steps to assign a value to `hostingAccountHandlerRoleArnParamStorePath` parameter in `./integration-tests/config/<STAGE>.yaml` file
-    1. Uncomment `hostingAccountHandlerRoleArnParamStorePath` and provide a name for a SSM parameter that will contain the hosting account handler role ARN, e.g. `/swb/<STAGE>/accountsTest/hostingAccountHandlerRoleArn`.
-    1. Follow instructions to [create a SSM Parameter](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-create-console.html) in your main account and set the name as the assigned value in `hostingAccountHandlerRoleArnParamStorePath` and the value as the `HostingAccountHandlerRoleArn` parameter from [Deploy Hosting Account Step](#deploy-to-the-hosting-account).
-
-1. Follow these steps to assign a value to `envMgmtRoleArnParamStorePath` parameter in `./integration-tests/config/<STAGE>.yaml` file
-    1. Uncomment `envMgmtRoleArnParamStorePath` and provide a name for a SSM parameter that will contain the hosting account event management role ARN, e.g. `/swb/<STAGE>/accountsTest/envMgmtRoleArn`.
-    1. Follow instructions to [create a SSM Parameter](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-create-console.html) in your main account and set the name as the assigned value in `envMgmtRoleArnParamStorePath` and the value as the `EnvMgmtRoleArn` parameter from [Deploy Hosting Account Step](#deploy-to-the-hosting-account).
-
-1. Follow these steps to assign a value to `encryptionKeyArnParamStorePath` parameter in `./integration-tests/config/<STAGE>.yaml` file
-    1. Uncomment `encryptionKeyArnParamStorePath` and provide a name for a SSM parameter that will contain the hosting account encryption key ARN, e.g. `/swb/<STAGE>/accountsTest/encryptionKeyArn`.
-    1. Follow instructions to [create a SSM Parameter](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-create-console.html) in your main account and set the name as the assigned value in `encryptionKeyArnParamStorePath` and the value as the `EncryptionKeyArn` parameter from [Deploy Hosting Account Step](#deploy-to-the-hosting-account).
+1. Follow these steps to assign a value to `awsAccountIdParamStorePath` parameter in `./integration-tests/config/<STAGE>.yaml` file. This value is necessary to run teh AWS Accounts multi-step integration test. If the value remains commented out, this test will not run.
+    1. Uncomment `awsAccountIdParamStorePath` and provide a name for a SSM parameter that will contain the 12 Digit Account Id of an AWS Account you own that is not the main nor hosting account ID, e.g. `/swb/<STAGE>/accountsTest/awsAccountId`.
+    1. Follow instructions to [create a SSM Parameter](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-create-console.html) in your main account and set the name as the assigned value in `awsAccountIdParamStorePath` and the value as the the 12 Digit Hosting Account Id.
 
 1. Uncomment `defaultHostingAccountId` and in `./integration-tests/config/<STAGE>.yaml` file and assign value `ACCOUNT_ID` from [Onboard Hosting Account Step](#onboard-hosting-account).
 

--- a/solutions/swb-reference/integration-tests/config/example.yaml
+++ b/solutions/swb-reference/integration-tests/config/example.yaml
@@ -8,9 +8,6 @@
 #projectId: ''  #ex: proj-3656712-bvf8-47ds-r3fv-9dsb9sdyfba2
 #envType: ''
 
-## Negative Testing
-#terminatedEnvId: ''   # id of an environment that has already been terminated
-
 ## Cognito Integ Test Client
 #rootUserNameParamStorePath: ''
 #rootPasswordParamStorePath: ''
@@ -28,8 +25,5 @@
 #defaultHostingAccountId: ''     # exp: acc-2272f4a8-1791-419a-8e49-b926f3eb46f9
 
 ## Pre-requisite for running aws-accounts integration test
-## Create the onboard_account stack in an external AWS account, and populate the following values below:
-# hostAwsAccountIdParamStorePath: ''
-# hostingAccountHandlerRoleArnParamStorePath: ''
-# envMgmtRoleArnParamStorePath: ''
-# encryptionKeyArnParamStorePath: ''
+## Store an AWS Account ID that is not your main or hosting account ID in SSM and provide path here
+#awsAccountIdParamStorePath: ''

--- a/solutions/swb-reference/integration-tests/support/complex/accountHelper.ts
+++ b/solutions/swb-reference/integration-tests/support/complex/accountHelper.ts
@@ -81,8 +81,8 @@ export class AccountHelper {
   }
 
   public async removeAccountFromKeyPolicy(awsAccountId: string): Promise<void> {
-    const mainAcctS3ArtifactEncryptionArn = this._settings.get('MainAccountS3ArtifactEncryptionKeyOutput');
-    const mainAcctS3DatasetsEncryptionArn = this._settings.get('MainAccountS3DatasetsEncryptionKeyOutput');
+    const mainAcctS3ArtifactEncryptionArn = this._settings.get('S3ArtifactEncryptionKeyOutputCC25B0CD');
+    const mainAcctS3DatasetsEncryptionArn = this._settings.get('S3DatasetsEncryptionKeyOutput05C7794D');
     const mainAcctEncryptionArnList = [mainAcctS3ArtifactEncryptionArn, mainAcctS3DatasetsEncryptionArn];
     await Promise.all(
       _.map(mainAcctEncryptionArnList, async (mainAcctEncryptionArn) => {
@@ -141,7 +141,7 @@ export class AccountHelper {
   }
 
   public async deOnboardAccount(awsAccountId: string): Promise<void> {
-    // Undo all operations that happen in: hostingAccountLifecycleService.initializeAccount()
+    // Undo all operations that happen in: hostingAccountLifecycleService.createAccount()
 
     // Update main account default event bus to remove hosting account state change events
     await this.removeBusPermissions(awsAccountId);

--- a/solutions/swb-reference/integration-tests/support/resources/accounts/account.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/accounts/account.ts
@@ -19,11 +19,10 @@ export default class Account extends Resource {
     const existingAccounts = await accountHelper.listOnboardedAccounts();
     const resource = _.find(existingAccounts, { awsAccountId: settings.get('hostAwsAccountId') });
 
-    console.log(resource);
-    // if (resource) {
-    //   const { id, awsAccountId } = resource;
-    //   await accountHelper.deOnboardAccount(awsAccountId);
-    //   await accountHelper.deleteDdbRecords(id, awsAccountId);
-    // }
+    if (resource) {
+      const { id, awsAccountId } = resource;
+      await accountHelper.deOnboardAccount(awsAccountId);
+      await accountHelper.deleteDdbRecords(id, awsAccountId);
+    }
   }
 }

--- a/solutions/swb-reference/integration-tests/support/resources/accounts/account.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/accounts/account.ts
@@ -17,7 +17,7 @@ export default class Account extends Resource {
     const accountHelper = new AccountHelper();
     const settings = this._setup.getSettings();
     const existingAccounts = await accountHelper.listOnboardedAccounts();
-    const resource = _.find(existingAccounts, { awsAccountId: settings.get('hostAwsAccountId') });
+    const resource = _.find(existingAccounts, { awsAccountId: settings.get('awsAccountId') });
 
     if (resource) {
       const { id, awsAccountId } = resource;

--- a/solutions/swb-reference/integration-tests/support/setup.ts
+++ b/solutions/swb-reference/integration-tests/support/setup.ts
@@ -154,17 +154,10 @@ export default class Setup {
   }
 
   private async _loadSecrets(secretsService: SecretsService): Promise<void> {
-    const [hostAwsAccountId, hostingAccountHandlerRoleArn, envMgmtRoleArn, encryptionKeyArn] =
-      await Promise.all([
-        secretsService.getSecret(this._settings.get('hostAwsAccountIdParamStorePath')),
-        secretsService.getSecret(this._settings.get('hostingAccountHandlerRoleArnParamStorePath')),
-        secretsService.getSecret(this._settings.get('envMgmtRoleArnParamStorePath')),
-        secretsService.getSecret(this._settings.get('encryptionKeyArnParamStorePath'))
-      ]);
+    const [awsAccountId] = await Promise.all([
+      secretsService.getSecret(this._settings.get('awsAccountIdParamStorePath'))
+    ]);
 
-    this._settings.set('hostAwsAccountId', hostAwsAccountId);
-    this._settings.set('hostingAccountHandlerRoleArn', hostingAccountHandlerRoleArn);
-    this._settings.set('envMgmtRoleArn', envMgmtRoleArn);
-    this._settings.set('encryptionKeyArn', encryptionKeyArn);
+    this._settings.set('awsAccountId', awsAccountId);
   }
 }

--- a/solutions/swb-reference/integration-tests/support/setup.ts
+++ b/solutions/swb-reference/integration-tests/support/setup.ts
@@ -154,6 +154,9 @@ export default class Setup {
   }
 
   private async _loadSecrets(secretsService: SecretsService): Promise<void> {
+    if (this._settings.optional('awsAccountIdParamStorePath', undefined) === undefined) {
+      return;
+    }
     const [awsAccountId] = await Promise.all([
       secretsService.getSecret(this._settings.get('awsAccountIdParamStorePath'))
     ]);

--- a/solutions/swb-reference/integration-tests/support/utils/settings.ts
+++ b/solutions/swb-reference/integration-tests/support/utils/settings.ts
@@ -24,8 +24,8 @@ interface Setting {
 
   // Main CFN template outputs
   cognitoUserPoolClientId: string;
-  MainAccountS3ArtifactEncryptionKeyOutput: string;
-  MainAccountS3DatasetsEncryptionKeyOutput: string;
+  S3DatasetsEncryptionKeyOutput05C7794D: string;
+  S3ArtifactEncryptionKeyOutputCC25B0CD: string;
   SagemakerNotebookTerminateSSMDocOutput: string;
   awsRegion: string;
   DataSetsBucketName: string;
@@ -52,14 +52,8 @@ interface Setting {
   defaultHostingAccountId: string;
 
   // Configs for AWS Account onboard test
-  hostAwsAccountId: string;
-  hostAwsAccountIdParamStorePath: string;
-  envMgmtRoleArn: string;
-  envMgmtRoleArnParamStorePath: string;
-  hostingAccountHandlerRoleArn: string;
-  hostingAccountHandlerRoleArnParamStorePath: string;
-  encryptionKeyArn: string;
-  encryptionKeyArnParamStorePath: string;
+  awsAccountId: string;
+  awsAccountIdParamStorePath: string;
 
   // Derived
   mainAccountId: string;

--- a/solutions/swb-reference/integration-tests/tests/multiStep/awsAccount.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/awsAccount.test.ts
@@ -16,8 +16,6 @@ describe('multiStep awsAccount integration test', () => {
   const settings: Settings = setup.getSettings();
   let adminSession: ClientSession;
 
-  const testIf = settings.optional('awsAccountId', undefined) !== undefined ? test : test.skip;
-
   beforeAll(async () => {
     adminSession = await setup.getDefaultAdminSession();
   });
@@ -27,48 +25,52 @@ describe('multiStep awsAccount integration test', () => {
   });
 
   test('it works', async () => {
-    const stackName = setup.getStackName();
+    if (settings.optional('awsAccountId', undefined) !== undefined) {
+      const stackName = setup.getStackName();
 
-    const randomTextGenerator = new RandomTextGenerator(setup.getSettings().get('runId'));
+      const randomTextGenerator = new RandomTextGenerator(setup.getSettings().get('runId'));
 
-    const awsAccountIdToUse = settings.get('awsAccountId');
+      const awsAccountIdToUse = settings.get('awsAccountId');
 
-    const createAccountParams: CreateAccountRequest = {
-      hostingAccountHandlerRoleArn: `arn:aws:iam::${awsAccountIdToUse}:role/${stackName}-hosting-account-role`,
-      awsAccountId: awsAccountIdToUse,
-      envMgmtRoleArn: `arn:aws:iam::${awsAccountIdToUse}:role/${stackName}-env-mgmt`,
-      name: randomTextGenerator.getFakeText('fakeName'),
-      externalId: 'workbench'
-    };
+      const createAccountParams: CreateAccountRequest = {
+        hostingAccountHandlerRoleArn: `arn:aws:iam::${awsAccountIdToUse}:role/${stackName}-hosting-account-role`,
+        awsAccountId: awsAccountIdToUse,
+        envMgmtRoleArn: `arn:aws:iam::${awsAccountIdToUse}:role/${stackName}-env-mgmt`,
+        name: randomTextGenerator.getFakeText('fakeName'),
+        externalId: 'workbench'
+      };
 
-    const createResponse = await adminSession.resources.accounts.create(createAccountParams, false);
-    expect(createResponse.status).toEqual(201);
+      const createResponse = await adminSession.resources.accounts.create(createAccountParams, false);
+      expect(createResponse.status).toEqual(201);
 
-    const accountId = createResponse.data.id;
-    expect(accountId).toBeTruthy();
+      const accountId = createResponse.data.id;
+      expect(accountId).toBeTruthy();
 
-    const accountHelper = new AccountHelper();
-    const doesBusAllowAccount = await accountHelper.verifyBusAllowsAccount(createAccountParams.awsAccountId);
-    expect(doesBusAllowAccount).toBe(true);
+      const accountHelper = new AccountHelper();
+      const doesBusAllowAccount = await accountHelper.verifyBusAllowsAccount(
+        createAccountParams.awsAccountId
+      );
+      expect(doesBusAllowAccount).toBe(true);
 
-    const hostingAccountTemplateResponse = await adminSession.resources.accounts.getHostingAccountTemplate(
-      accountId
-    );
-    expect(hostingAccountTemplateResponse.status).toEqual(200);
-    expect(Object.keys(hostingAccountTemplateResponse.data).length).toEqual(3); // Should get three sets of template URLs
+      const hostingAccountTemplateResponse = await adminSession.resources.accounts.getHostingAccountTemplate(
+        accountId
+      );
+      expect(hostingAccountTemplateResponse.status).toEqual(200);
+      expect(Object.keys(hostingAccountTemplateResponse.data).length).toEqual(3); // Should get three sets of template URLs
 
-    const listResponse = await adminSession.resources.accounts.get({ pageSize: `100` });
-    expect(listResponse.status).toEqual(200);
-    expect(listResponse.data.data.some((item: Account) => item.id === accountId)).toBe(true);
+      const listResponse = await adminSession.resources.accounts.get({ pageSize: `100` });
+      expect(listResponse.status).toEqual(200);
+      expect(listResponse.data.data.some((item: Account) => item.id === accountId)).toBe(true);
 
-    const getResponse = await adminSession.resources.accounts.account(accountId).get();
-    expect(getResponse.status).toEqual(200);
-    expect(getResponse.data.id).toEqual(accountId);
+      const getResponse = await adminSession.resources.accounts.account(accountId).get();
+      expect(getResponse.status).toEqual(200);
+      expect(getResponse.data.id).toEqual(accountId);
 
-    const dateString = new Date().toISOString().replace(/:/g, '');
-    const name = `integrationTest${dateString}`;
-    const updateResponse = await adminSession.resources.accounts.account(accountId).update({ name }, true);
-    expect(updateResponse.status).toEqual(200);
-    expect(updateResponse.data.name).toEqual(name);
+      const dateString = new Date().toISOString().replace(/:/g, '');
+      const name = `integrationTest${dateString}`;
+      const updateResponse = await adminSession.resources.accounts.account(accountId).update({ name }, true);
+      expect(updateResponse.status).toEqual(200);
+      expect(updateResponse.data.name).toEqual(name);
+    }
   });
 });

--- a/solutions/swb-reference/integration-tests/tests/multiStep/awsAccount.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/awsAccount.test.ts
@@ -3,10 +3,8 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { AccountService, CreateAccountRequest } from '@aws/workbench-core-accounts';
+import { CreateAccountRequest } from '@aws/workbench-core-accounts';
 import { Account } from '@aws/workbench-core-accounts/lib/models/accounts/account';
-import { resourceTypeToKey } from '@aws/workbench-core-base';
-import DynamoDBService from '@aws/workbench-core-base/lib/aws/helpers/dynamoDB/dynamoDBService';
 import ClientSession from '../../support/clientSession';
 import { AccountHelper } from '../../support/complex/accountHelper';
 import Setup from '../../support/setup';
@@ -18,6 +16,8 @@ describe('multiStep awsAccount integration test', () => {
   const settings: Settings = setup.getSettings();
   let adminSession: ClientSession;
 
+  const testIf = settings.optional('awsAccountId', undefined) !== undefined ? test : test.skip;
+
   beforeAll(async () => {
     adminSession = await setup.getDefaultAdminSession();
   });
@@ -27,33 +27,19 @@ describe('multiStep awsAccount integration test', () => {
   });
 
   test('it works', async () => {
-    const dynamoDbService = new DynamoDBService({
-      region: settings.get('awsRegion'),
-      table: setup.getStackName()
-    });
-    const accountService = new AccountService(dynamoDbService);
+    const stackName = setup.getStackName();
 
     const randomTextGenerator = new RandomTextGenerator(setup.getSettings().get('runId'));
 
+    const awsAccountIdToUse = settings.get('awsAccountId');
+
     const createAccountParams: CreateAccountRequest = {
-      hostingAccountHandlerRoleArn: settings.get('hostingAccountHandlerRoleArn'),
-      awsAccountId: settings.get('hostAwsAccountId'),
-      envMgmtRoleArn: settings.get('envMgmtRoleArn'),
+      hostingAccountHandlerRoleArn: `arn:aws:iam::${awsAccountIdToUse}:role/${stackName}-hosting-account-role`,
+      awsAccountId: awsAccountIdToUse,
+      envMgmtRoleArn: `arn:aws:iam::${awsAccountIdToUse}:role/${stackName}-env-mgmt`,
       name: randomTextGenerator.getFakeText('fakeName'),
       externalId: 'workbench'
     };
-
-    const hostingAwsAccountId = `${resourceTypeToKey.awsAccount}#${createAccountParams.awsAccountId}`;
-    const query = { key: { name: 'pk', value: hostingAwsAccountId } };
-    const ddbEntries = await dynamoDbService.getPaginatedItems(query);
-    if (ddbEntries.data.length > 0) {
-      const accountId = ddbEntries.data[0].accountId.toString();
-      const awsAccountItemKey = {
-        pk: hostingAwsAccountId,
-        sk: `${resourceTypeToKey.account}#${accountId}`
-      };
-      await dynamoDbService.delete(awsAccountItemKey).execute();
-    }
 
     const createResponse = await adminSession.resources.accounts.create(createAccountParams, false);
     expect(createResponse.status).toEqual(201);
@@ -61,12 +47,15 @@ describe('multiStep awsAccount integration test', () => {
     const accountId = createResponse.data.id;
     expect(accountId).toBeTruthy();
 
-    expect(await new AccountHelper().verifyBusAllowsAccount(createAccountParams.awsAccountId)).toBe(true);
+    const accountHelper = new AccountHelper();
+    const doesBusAllowAccount = await accountHelper.verifyBusAllowsAccount(createAccountParams.awsAccountId);
+    expect(doesBusAllowAccount).toBe(true);
 
     const hostingAccountTemplateResponse = await adminSession.resources.accounts.getHostingAccountTemplate(
       accountId
     );
     expect(hostingAccountTemplateResponse.status).toEqual(200);
+    expect(Object.keys(hostingAccountTemplateResponse.data).length).toEqual(3); // Should get three sets of template URLs
 
     const listResponse = await adminSession.resources.accounts.get({ pageSize: `100` });
     expect(listResponse.status).toEqual(200);
@@ -81,7 +70,5 @@ describe('multiStep awsAccount integration test', () => {
     const updateResponse = await adminSession.resources.accounts.account(accountId).update({ name }, true);
     expect(updateResponse.status).toEqual(200);
     expect(updateResponse.data.name).toEqual(name);
-
-    await accountService.delete(accountId);
   });
 });

--- a/workbench-core/accounts/src/services/accountService.ts
+++ b/workbench-core/accounts/src/services/accountService.ts
@@ -5,7 +5,6 @@
 
 import { GetItemCommandOutput } from '@aws-sdk/client-dynamodb';
 import {
-  buildDynamoDBPkSk,
   PaginatedResponse,
   QueryParams,
   resourceTypeToKey,
@@ -65,15 +64,6 @@ export default class AccountService {
       });
     }
     return accounts;
-  }
-
-  /**
-   * Delete a hosting account record in DDB
-   * @param accountId - The ID of the account to delete
-   */
-  public async delete(accountId: string): Promise<void> {
-    const accountKey = buildDynamoDBPkSk(accountId, resourceTypeToKey.account);
-    await this._dynamoDBService.delete(accountKey).execute();
   }
 
   /**


### PR DESCRIPTION
Issue #, if available: GALI-2497

Description of changes:
Re-do the test logic to not have conflicting resources.
This now requires you to supply a AWS Account ID that is neither a hosting nor main account for the deployment you are testing against. Because of this, I made the test conditionally run so customers do not have to run the account test if the additional account is too much overhead. For devs, we are fine with this additional prereq.
Now comes in _**Optional!**_

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.