### PR TITLE
fix: create account should throw 400 error instead of 500 errors for incorrect accountId and arns

### DIFF
--- a/common/changes/@aws/swb-app/thingut-hosting-account-validation_2023-06-04-16-21.json
+++ b/common/changes/@aws/swb-app/thingut-hosting-account-validation_2023-06-04-16-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-app",
+      "comment": "account creation validation updates",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/swb-app"
+}

--- a/common/changes/@aws/workbench-core-accounts/thingut-hosting-account-validation_2023-06-04-16-13.json
+++ b/common/changes/@aws/workbench-core-accounts/thingut-hosting-account-validation_2023-06-04-16-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-accounts",
+      "comment": "error validation for create account",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-accounts"
+}

--- a/common/changes/@aws/workbench-core-base/thingut-hosting-account-validation_2023-06-04-16-21.json
+++ b/common/changes/@aws/workbench-core-base/thingut-hosting-account-validation_2023-06-04-16-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-base",
+      "comment": "regular expression updates for creating account",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-base"
+}

--- a/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/create.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/create.test.ts
@@ -40,11 +40,8 @@ describe('awsAccounts create negative tests', () => {
   };
 
   describe('when creating an account', () => {
-    //TODO: Add the following tests
-    // 1. Incorrect envMgmtRole Arn and hostingAccountHandlerRoleArn
-    // 2. AccountId that does not exist
     describe('and the creation params are invalid', () => {
-      test('it throws a validation error', async () => {
+      test('with empty body it throws a validation error', async () => {
         try {
           await adminSession.resources.accounts.create({}, false);
         } catch (e) {
@@ -54,6 +51,53 @@ describe('awsAccounts create negative tests', () => {
               error: 'Bad Request',
               message:
                 'name: Required. awsAccountId: Required. envMgmtRoleArn: Required. hostingAccountHandlerRoleArn: Required. externalId: Required'
+            })
+          );
+        }
+      });
+      test('with accountId that is too long it throws a validation error', async () => {
+        try {
+          const body = { ...validLaunchParameters };
+          body.awsAccountId = '123456789012345';
+          await adminSession.resources.accounts.create(body, false);
+        } catch (e) {
+          checkHttpError(
+            e,
+            new HttpError(400, {
+              error: 'Bad Request',
+              message: 'awsAccountId: must be a 12 digit number'
+            })
+          );
+        }
+      });
+      test('with accountId of account that does not exist it throws a validation error', async () => {
+        try {
+          const body = { ...validLaunchParameters };
+          body.awsAccountId = '123456789012';
+          await adminSession.resources.accounts.create(body, false);
+        } catch (e) {
+          checkHttpError(
+            e,
+            new HttpError(400, {
+              error: 'Bad Request',
+              message: "Please provide a valid 'awsAccountId' for the hosting account"
+            })
+          );
+        }
+      });
+      test('with incorrect envMgtmRoleArn and hostingAccountHandlerRoleArn it throws a validation error', async () => {
+        try {
+          const body = { ...validLaunchParameters };
+          body.envMgmtRoleArn = 'fakeValue';
+          body.hostingAccountHandlerRoleArn = 'fakeValue';
+          await adminSession.resources.accounts.create(body, false);
+        } catch (e) {
+          checkHttpError(
+            e,
+            new HttpError(400, {
+              error: 'Bad Request',
+              message:
+                'envMgmtRoleArn: must be a valid envMgmtRoleArn. hostingAccountHandlerRoleArn: must be a valid hostingAccountHandlerRoleArn'
             })
           );
         }

--- a/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/create.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/create.test.ts
@@ -28,9 +28,13 @@ describe('awsAccounts create negative tests', () => {
   });
 
   const validLaunchParameters = {
-    awsAccountId: randomTextGenerator.getFakeText('fakeAccount'),
-    envMgmtRoleArn: randomTextGenerator.getFakeText('fakeEnvMgmtRoleArn'),
-    hostingAccountHandlerRoleArn: randomTextGenerator.getFakeText('fakeHostingAccountHandlerRoleArn'),
+    awsAccountId: '123456789012',
+    envMgmtRoleArn: `arn:aws:iam::123456789012:role/${randomTextGenerator.getFakeText(
+      'fakeEnvMgmtRoleArn'
+    )}-env-mgmt`,
+    hostingAccountHandlerRoleArn: `arn:aws:iam::123456789012:role/${randomTextGenerator.getFakeText(
+      'fakeHostingAccountHandlerRoleArn'
+    )}-hosting-account-role`,
     name: randomTextGenerator.getFakeText('fakeName'),
     externalId: randomTextGenerator.getFakeText('fakeExternalId')
   };
@@ -59,6 +63,7 @@ describe('awsAccounts create negative tests', () => {
         const existingAccounts = await accountHelper.listOnboardedAccounts();
 
         invalidParam.awsAccountId = _.first(existingAccounts)!.awsAccountId;
+
         try {
           await adminSession.resources.accounts.create(invalidParam, false);
         } catch (e) {

--- a/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/create.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/create.test.ts
@@ -40,6 +40,9 @@ describe('awsAccounts create negative tests', () => {
   };
 
   describe('when creating an account', () => {
+    //TODO: Add the following tests
+    // 1. Incorrect envMgmtRole Arn and hostingAccountHandlerRoleArn
+    // 2. AccountId that does not exist
     describe('and the creation params are invalid', () => {
       test('it throws a validation error', async () => {
         try {

--- a/workbench-core/accounts/src/errors/InvalidAwsAccountIdError.ts
+++ b/workbench-core/accounts/src/errors/InvalidAwsAccountIdError.ts
@@ -1,0 +1,25 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+export class InvalidAwsAccountIdError extends Error {
+  public readonly isInvalidAwsAccountIdError: boolean;
+
+  public constructor(message?: string) {
+    super(message);
+    this.name = this.constructor.name;
+    this.isInvalidAwsAccountIdError = true;
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, InvalidAwsAccountIdError);
+    }
+  }
+}
+
+export function isInvalidAwsAccountIdError(error: unknown): error is InvalidAwsAccountIdError {
+  return (
+    Boolean(error) &&
+    error instanceof Error &&
+    (error as InvalidAwsAccountIdError).isInvalidAwsAccountIdError === true
+  );
+}

--- a/workbench-core/accounts/src/errors/errors.test.ts
+++ b/workbench-core/accounts/src/errors/errors.test.ts
@@ -1,0 +1,14 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InvalidAwsAccountIdError, isInvalidAwsAccountIdError } from './InvalidAwsAccountIdError';
+
+describe('custom error tests', () => {
+  test('InvalidAwsAccountIdError', () => {
+    const invalidAwsAccountIdError = new InvalidAwsAccountIdError();
+
+    expect(isInvalidAwsAccountIdError(invalidAwsAccountIdError)).toBe(true);
+  });
+});

--- a/workbench-core/accounts/src/index.ts
+++ b/workbench-core/accounts/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { ProjectStatus } from './constants/projectStatus';
+import { isInvalidAwsAccountIdError } from './errors/InvalidAwsAccountIdError';
 import AccountHandler from './handlers/accountHandler';
 import {
   AwsAccountTemplateUrlsRequest,
@@ -86,5 +87,6 @@ export {
   AssignUserToProjectRequestParser,
   AssignUserToProjectRequest,
   Project,
-  ProjectStatus
+  ProjectStatus,
+  isInvalidAwsAccountIdError
 };

--- a/workbench-core/accounts/src/models/accounts/createAccountRequest.ts
+++ b/workbench-core/accounts/src/models/accounts/createAccountRequest.ts
@@ -9,8 +9,8 @@ import { z } from '@aws/workbench-core-base';
 export const CreateAccountRequestParser = z.object({
   name: z.string().swbName().required(),
   awsAccountId: z.string().awsAccountId().required(),
-  envMgmtRoleArn: z.string().required(),
-  hostingAccountHandlerRoleArn: z.string().required(),
+  envMgmtRoleArn: z.string().envMgmtRoleArn().required(),
+  hostingAccountHandlerRoleArn: z.string().hostingAccountHandlerRoleArn().required(),
   externalId: z.string().required()
 });
 

--- a/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
+++ b/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
@@ -173,13 +173,7 @@ export default class HostingAccountLifecycleService {
     };
 
     // Update key policy
-    try {
-      await this._aws.clients.kms.putKeyPolicy(putPolicyParams);
-    } catch (e) {
-      if (e instanceof MalformedPolicyDocumentException) {
-        throw e;
-      }
-    }
+    await this._aws.clients.kms.putKeyPolicy(putPolicyParams);
   }
 
   /**

--- a/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
+++ b/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
@@ -212,10 +212,9 @@ export default class HostingAccountLifecycleService {
     try {
       await this._aws.clients.s3.putBucketPolicy(putPolicyParams);
     } catch (e) {
-      const detailErrorMessage = `"AWS" : "arn:aws:iam::${awsAccountId}:root"`;
       if (
-        e.Detail === detailErrorMessage &&
         e.name === 'MalformedPolicy' &&
+        e.Detail === `"AWS" : "arn:aws:iam::${awsAccountId}:root"` &&
         e instanceof S3ServiceException
       ) {
         throw new InvalidAwsAccountIdError("Please provide a valid 'awsAccountId' for the hosting account");

--- a/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
+++ b/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
@@ -6,7 +6,6 @@
 import { Readable } from 'stream';
 import { Output } from '@aws-sdk/client-cloudformation';
 import { ResourceNotFoundException } from '@aws-sdk/client-eventbridge';
-import { MalformedPolicyDocumentException } from '@aws-sdk/client-kms';
 import {
   GetBucketPolicyCommandOutput,
   PutBucketPolicyCommandInput,

--- a/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
+++ b/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
@@ -6,7 +6,13 @@
 import { Readable } from 'stream';
 import { Output } from '@aws-sdk/client-cloudformation';
 import { ResourceNotFoundException } from '@aws-sdk/client-eventbridge';
-import { GetBucketPolicyCommandOutput, PutBucketPolicyCommandInput, NoSuchBucket } from '@aws-sdk/client-s3';
+import { MalformedPolicyDocumentException } from '@aws-sdk/client-kms';
+import {
+  GetBucketPolicyCommandOutput,
+  PutBucketPolicyCommandInput,
+  NoSuchBucket,
+  S3ServiceException
+} from '@aws-sdk/client-s3';
 import {
   addPaginationToken,
   AwsService,
@@ -19,6 +25,7 @@ import * as Boom from '@hapi/boom';
 import { PolicyDocument, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import _ from 'lodash';
 import { HostingAccountStatus } from '../constants/hostingAccountStatus';
+import { InvalidAwsAccountIdError } from '../errors/InvalidAwsAccountIdError';
 import { AccountCfnTemplateParameters, TemplateResponse } from '../models/accountCfnTemplate';
 import { Account } from '../models/accounts/account';
 import { AwsAccountTemplateUrlsRequest } from '../models/accounts/awsAccountTemplateUrlsRequest';
@@ -166,7 +173,13 @@ export default class HostingAccountLifecycleService {
     };
 
     // Update key policy
-    await this._aws.clients.kms.putKeyPolicy(putPolicyParams);
+    try {
+      await this._aws.clients.kms.putKeyPolicy(putPolicyParams);
+    } catch (e) {
+      if (e instanceof MalformedPolicyDocumentException) {
+        throw e;
+      }
+    }
   }
 
   /**
@@ -203,7 +216,19 @@ export default class HostingAccountLifecycleService {
     };
 
     // Update bucket policy
-    await this._aws.clients.s3.putBucketPolicy(putPolicyParams);
+    try {
+      await this._aws.clients.s3.putBucketPolicy(putPolicyParams);
+    } catch (e) {
+      const detailErrorMessage = `"AWS" : "arn:aws:iam::${awsAccountId}:root"`;
+      if (
+        e.Detail === detailErrorMessage &&
+        e.name === 'MalformedPolicy' &&
+        e instanceof S3ServiceException
+      ) {
+        throw new InvalidAwsAccountIdError("Please provide a valid 'awsAccountId' for the hosting account");
+      }
+      throw e;
+    }
   }
 
   private _updateBucketPolicyDocumentWithAllStatements(
@@ -651,11 +676,11 @@ export default class HostingAccountLifecycleService {
   }): Promise<void> {
     const { statusHandlerArn, artifactBucketArn, mainAcctEncryptionArnList } = arns;
 
-    // Update main account default event bus to accept hosting account state change events
-    await this.updateBusPermissions(statusHandlerArn, awsAccountId);
-
     // Add account to artifactBucket's bucket policy
     await this.updateArtifactsBucketPolicy(artifactBucketArn, awsAccountId);
+
+    // Update main account default event bus to accept hosting account state change events
+    await this.updateBusPermissions(statusHandlerArn, awsAccountId);
 
     // Update main account encryption key policy
     await Promise.all(

--- a/workbench-core/base/src/utilities/textUtil.ts
+++ b/workbench-core/base/src/utilities/textUtil.ts
@@ -41,6 +41,13 @@ const groupIDRegExpAsString: string = '\\S{1,128}';
 const awsAccountIdMessage: string = 'must be a 12 digit number';
 const awsAccountIdRegExpAsString: string = '^[0-9]{12}$';
 
+const envMgmtRoleArnMessage: string = 'must be a valid envMgmtRoleArn';
+const envMgmtRoleArnRegExpAsString: string = '^arn:aws:iam::[0-9]{12}:role\\/[\\w-]+-env-mgmt$';
+
+const hostingAccountHandlerRoleArnMessage: string = 'must be a valid hostingAccountHandlerRoleArn';
+const hostingAccountHandlerRoleArnRegExpAsString: string =
+  '^arn:aws:iam::[0-9]{12}:role\\/[\\w-]+hosting-account-role$';
+
 const awsRegionMessage: string = 'must be valid AWS region';
 const awsRegionRegExpAsString: string = '^(us|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\\d$';
 
@@ -136,6 +143,16 @@ function awsAccountIdRegExp(): RegExp {
   return new RegExp(awsAccountIdRegExpAsString);
 }
 
+function envMgmtRoleArnRegExp(): RegExp {
+  // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
+  return new RegExp(envMgmtRoleArnRegExpAsString);
+}
+
+function hostingAccountHandlerRoleArnRegExp(): RegExp {
+  // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
+  return new RegExp(hostingAccountHandlerRoleArnRegExpAsString);
+}
+
 function sshKeyIdRegex(): RegExp {
   // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
   return new RegExp(sshKeyIdRegExpString);
@@ -190,5 +207,9 @@ export {
   lengthValidationMessage,
   sshKeyIdRegex,
   userIdRegex,
-  datasetIdRegex
+  datasetIdRegex,
+  envMgmtRoleArnRegExp,
+  envMgmtRoleArnMessage,
+  hostingAccountHandlerRoleArnMessage,
+  hostingAccountHandlerRoleArnRegExp
 };

--- a/workbench-core/base/src/utilities/validatorHelper.ts
+++ b/workbench-core/base/src/utilities/validatorHelper.ts
@@ -34,7 +34,11 @@ import {
   awsRegionMessage,
   sshKeyIdRegex,
   userIdRegex,
-  datasetIdRegex
+  datasetIdRegex,
+  envMgmtRoleArnRegExp,
+  envMgmtRoleArnMessage,
+  hostingAccountHandlerRoleArnMessage,
+  hostingAccountHandlerRoleArnRegExp
 } from './textUtil';
 
 interface ZodPagination {
@@ -60,6 +64,8 @@ declare module 'zod' {
     awsRegion: () => ZodString;
     optionalNonEmpty: () => ZodOptional<ZodString>;
     awsAccountId: () => ZodString;
+    envMgmtRoleArn: () => ZodString;
+    hostingAccountHandlerRoleArn: () => ZodString;
     sshKeyId: () => ZodString;
     userId: () => ZodString;
   }
@@ -144,6 +150,14 @@ z.ZodString.prototype.optionalNonEmpty = function (): ZodOptional<ZodString> {
 
 z.ZodString.prototype.awsAccountId = function (): ZodString {
   return this.regex(awsAccountIdRegExp(), { message: awsAccountIdMessage });
+};
+
+z.ZodString.prototype.envMgmtRoleArn = function (): ZodString {
+  return this.regex(envMgmtRoleArnRegExp(), { message: envMgmtRoleArnMessage });
+};
+
+z.ZodString.prototype.hostingAccountHandlerRoleArn = function (): ZodString {
+  return this.regex(hostingAccountHandlerRoleArnRegExp(), { message: hostingAccountHandlerRoleArnMessage });
 };
 
 z.ZodString.prototype.awsRegion = function (): ZodString {


### PR DESCRIPTION
Description of changes:

Add additional Input validation for creating new hosting accounts
* User must provide an `awsAccountId` of a real account
* `envMgmtRoleArn` and `hostingAccountHandlerRole` arn must follow the proper ARN format. 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.