### PR TITLE
fix: fix Dataset Edge Cases

### DIFF
--- a/common/changes/@aws/swb-app/release-v2.0.0_2023-06-05-09-05.json
+++ b/common/changes/@aws/swb-app/release-v2.0.0_2023-06-05-09-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-app",
+      "comment": "Update Datasets and  Create Project Environment Route to address Dataset edge cases",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/swb-app"
+}

--- a/common/changes/@aws/workbench-core-base/release-v2.0.0_2023-06-05-09-05.json
+++ b/common/changes/@aws/workbench-core-base/release-v2.0.0_2023-06-05-09-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-base",
+      "comment": "Add utility for concatenating multiple keys into SK",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-base"
+}

--- a/common/changes/@aws/workbench-core-environments/release-v2.0.0_2023-06-05-09-05.json
+++ b/common/changes/@aws/workbench-core-environments/release-v2.0.0_2023-06-05-09-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-environments",
+      "comment": "Add Project to Dataset+Endpoint metadata to track relationship during environment create/delete",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-environments"
+}

--- a/solutions/swb-app/src/dataSetRoutes.ts
+++ b/solutions/swb-app/src/dataSetRoutes.ts
@@ -101,7 +101,7 @@ export function setUpDSRoutes(router: Router, dataSetService: DataSetPlugin): vo
 
   // Add file to dataset
   router.get(
-    '/projects/:projectsId/datasets/:dataSetId/upload-requests',
+    '/projects/:projectId/datasets/:dataSetId/upload-requests',
     wrapAsync(async (req: Request, res: Response) => {
       if (req.params.dataSetId.match(uuidWithLowercasePrefixRegExp(resourceTypeToKey.dataset)) === null) {
         throw Boom.badRequest('dataSetId request parameter is invalid');
@@ -221,7 +221,17 @@ export function setUpDSRoutes(router: Router, dataSetService: DataSetPlugin): vo
         }
       );
 
-      await dataSetService.removeAccessForProject(validatedRequest);
+      try {
+        await dataSetService.removeAccessForProject(validatedRequest);
+      } catch (e) {
+        console.error(e);
+
+        if (isConflictError(e)) {
+          throw Boom.conflict(e.message);
+        }
+
+        throw Boom.badImplementation(`There was a problem deleting ${req.params.datasetId}`);
+      }
 
       res.status(204).send();
     })

--- a/solutions/swb-app/src/dataSetRoutes.ts
+++ b/solutions/swb-app/src/dataSetRoutes.ts
@@ -230,7 +230,7 @@ export function setUpDSRoutes(router: Router, dataSetService: DataSetPlugin): vo
           throw Boom.conflict(e.message);
         }
 
-        throw Boom.badImplementation(`There was a problem deleting ${req.params.datasetId}`);
+        throw Boom.badImplementation(`There was a problem removing access to ${req.params.datasetId}`);
       }
 
       res.status(204).send();

--- a/solutions/swb-app/src/dataSets/dataSetPlugin.ts
+++ b/solutions/swb-app/src/dataSets/dataSetPlugin.ts
@@ -16,6 +16,7 @@ import { ListDataSetAccessPermissionsRequest } from './listDataSetAccessPermissi
 import { PermissionsResponse } from './permissionsResponseParser';
 import { ProjectAddAccessRequest } from './projectAddAccessRequestParser';
 import { ProjectRemoveAccessRequest } from './projectRemoveAccessRequestParser';
+import { VerifyProjectAccessForDatasetsRequest } from './verifyProjectAccessForDatasetsParser';
 
 export interface DataSetPlugin {
   storagePlugin: DataSetStoragePlugin;
@@ -56,4 +57,5 @@ export interface DataSetPlugin {
 
   addAccessForProject(request: ProjectAddAccessRequest): Promise<PermissionsResponse>;
   removeAccessForProject(request: ProjectRemoveAccessRequest): Promise<PermissionsResponse>;
+  verifyProjectAccessForDatasets(request: VerifyProjectAccessForDatasetsRequest): Promise<boolean>;
 }

--- a/solutions/swb-app/src/dataSets/dataSetPlugin.ts
+++ b/solutions/swb-app/src/dataSets/dataSetPlugin.ts
@@ -12,11 +12,11 @@ import { DataSetAddExternalEndpointResponse } from './dataSetAddExternalEndpoint
 import { DataSetExternalEndpointRequest } from './dataSetExternalEndpointRequest';
 import { DataSetStoragePlugin } from './dataSetStoragePlugin';
 import { GetAccessPermissionRequest } from './getAccessPermissionRequestParser';
+import { IsProjectAuthorizedForDatasetsRequest } from './isProjectAuthorizedForDatasetsParser';
 import { ListDataSetAccessPermissionsRequest } from './listDataSetAccessPermissionsRequestParser';
 import { PermissionsResponse } from './permissionsResponseParser';
 import { ProjectAddAccessRequest } from './projectAddAccessRequestParser';
 import { ProjectRemoveAccessRequest } from './projectRemoveAccessRequestParser';
-import { VerifyProjectAccessForDatasetsRequest } from './verifyProjectAccessForDatasetsParser';
 
 export interface DataSetPlugin {
   storagePlugin: DataSetStoragePlugin;
@@ -57,5 +57,5 @@ export interface DataSetPlugin {
 
   addAccessForProject(request: ProjectAddAccessRequest): Promise<PermissionsResponse>;
   removeAccessForProject(request: ProjectRemoveAccessRequest): Promise<PermissionsResponse>;
-  verifyProjectAccessForDatasets(request: VerifyProjectAccessForDatasetsRequest): Promise<boolean>;
+  isProjectAuthorizedForDatasets(request: IsProjectAuthorizedForDatasetsRequest): Promise<boolean>;
 }

--- a/solutions/swb-app/src/dataSets/isProjectAuthorizedForDatasetsParser.ts
+++ b/solutions/swb-app/src/dataSets/isProjectAuthorizedForDatasetsParser.ts
@@ -7,7 +7,7 @@ import { z } from '@aws/workbench-core-base';
 import { AuthenticatedUserParser } from '../users/authenticatedUser';
 
 // eslint-disable-next-line @rushstack/typedef-var
-export const VerifyProjectAccessForDatasetsParser = z
+export const IsProjectAuthorizedForDatasetsParser = z
   .object({
     authenticatedUser: AuthenticatedUserParser,
     datasetIds: z.array(z.string()),
@@ -15,4 +15,4 @@ export const VerifyProjectAccessForDatasetsParser = z
   })
   .strict();
 
-export type VerifyProjectAccessForDatasetsRequest = z.infer<typeof VerifyProjectAccessForDatasetsParser>;
+export type IsProjectAuthorizedForDatasetsRequest = z.infer<typeof IsProjectAuthorizedForDatasetsParser>;

--- a/solutions/swb-app/src/dataSets/verifyProjectAccessForDatasetsParser.ts
+++ b/solutions/swb-app/src/dataSets/verifyProjectAccessForDatasetsParser.ts
@@ -1,0 +1,18 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from '@aws/workbench-core-base';
+import { AuthenticatedUserParser } from '../users/authenticatedUser';
+
+// eslint-disable-next-line @rushstack/typedef-var
+export const VerifyProjectAccessForDatasetsParser = z
+  .object({
+    authenticatedUser: AuthenticatedUserParser,
+    datasetIds: z.array(z.string()),
+    projectId: z.string().required()
+  })
+  .strict();
+
+export type VerifyProjectAccessForDatasetsRequest = z.infer<typeof VerifyProjectAccessForDatasetsParser>;

--- a/solutions/swb-app/src/generateRouter.ts
+++ b/solutions/swb-app/src/generateRouter.ts
@@ -103,7 +103,12 @@ export function generateRouter(apiRouteConfig: ApiRouteConfig): Express {
     apiRouteConfig.metadataService,
     apiRouteConfig.userManagementService
   );
-  setUpProjectEnvRoutes(router, apiRouteConfig.environments, apiRouteConfig.projectEnvPlugin);
+  setUpProjectEnvRoutes(
+    router,
+    apiRouteConfig.environments,
+    apiRouteConfig.projectEnvPlugin,
+    apiRouteConfig.dataSetService
+  );
   setUpProjectEnvTypeConfigRoutes(router, apiRouteConfig.projectEnvTypeConfigPlugin);
   setUpSshKeyRoutes(router, apiRouteConfig.sshKeyService);
 

--- a/solutions/swb-app/src/index.ts
+++ b/solutions/swb-app/src/index.ts
@@ -16,6 +16,7 @@ import { DataSetPlugin } from './dataSets/dataSetPlugin';
 import { DataSetStoragePlugin } from './dataSets/dataSetStoragePlugin';
 import { GetAccessPermissionRequest } from './dataSets/getAccessPermissionRequestParser';
 import { PermissionsResponse, PermissionsResponseParser } from './dataSets/permissionsResponseParser';
+import { VerifyProjectAccessForDatasetsRequest } from './dataSets/verifyProjectAccessForDatasetsParser';
 import { Environment } from './environments/environment';
 import { EnvironmentItem } from './environments/environmentItem';
 import { EnvironmentPlugin } from './environments/environmentPlugin';
@@ -128,5 +129,6 @@ export {
   EnvironmentPlugin,
   ListEnvironmentsRequest,
   Environment,
-  EnvironmentItem
+  EnvironmentItem,
+  VerifyProjectAccessForDatasetsRequest
 };

--- a/solutions/swb-app/src/index.ts
+++ b/solutions/swb-app/src/index.ts
@@ -15,8 +15,8 @@ import { DataSetExternalEndpointRequest } from './dataSets/dataSetExternalEndpoi
 import { DataSetPlugin } from './dataSets/dataSetPlugin';
 import { DataSetStoragePlugin } from './dataSets/dataSetStoragePlugin';
 import { GetAccessPermissionRequest } from './dataSets/getAccessPermissionRequestParser';
+import { IsProjectAuthorizedForDatasetsRequest } from './dataSets/isProjectAuthorizedForDatasetsParser';
 import { PermissionsResponse, PermissionsResponseParser } from './dataSets/permissionsResponseParser';
-import { VerifyProjectAccessForDatasetsRequest } from './dataSets/verifyProjectAccessForDatasetsParser';
 import { Environment } from './environments/environment';
 import { EnvironmentItem } from './environments/environmentItem';
 import { EnvironmentPlugin } from './environments/environmentPlugin';
@@ -130,5 +130,5 @@ export {
   ListEnvironmentsRequest,
   Environment,
   EnvironmentItem,
-  VerifyProjectAccessForDatasetsRequest
+  IsProjectAuthorizedForDatasetsRequest
 };

--- a/solutions/swb-app/src/projectEnvironmentRoutes.ts
+++ b/solutions/swb-app/src/projectEnvironmentRoutes.ts
@@ -8,6 +8,7 @@ import { Environment } from '@aws/workbench-core-environments';
 import * as Boom from '@hapi/boom';
 import { NextFunction, Request, Response, Router } from 'express';
 import { EnvironmentUtilityServices } from './apiRouteConfig';
+import { DataSetPlugin } from './dataSets/dataSetPlugin';
 import { wrapAsync } from './errorHandlers';
 import { isProjectDeletedError } from './errors/projectDeletedError';
 import {
@@ -38,7 +39,8 @@ import { validateAndParse } from './validatorHelper';
 export function setUpProjectEnvRoutes(
   router: Router,
   environments: { [key: string]: EnvironmentUtilityServices },
-  projectEnvironmentService: ProjectEnvPlugin
+  projectEnvironmentService: ProjectEnvPlugin,
+  datasetService: DataSetPlugin
 ): void {
   const supportedEnvs = Object.keys(environments);
 
@@ -60,6 +62,17 @@ export function setUpProjectEnvRoutes(
       if (req.body.id) {
         throw Boom.badRequest(
           'id cannot be passed in the request body when trying to launch a new environment'
+        );
+      }
+
+      const unauthorizedDataset = await datasetService.verifyProjectAccessForDatasets({
+        authenticatedUser: res.locals.user,
+        datasetIds: environmentRequest.datasetIds,
+        projectId: req.params.projectId
+      });
+      if (unauthorizedDataset) {
+        throw Boom.forbidden(
+          `${environmentRequest.projectId} does not have access to the provided dataset(s)`
         );
       }
 

--- a/solutions/swb-app/src/projectEnvironmentRoutes.ts
+++ b/solutions/swb-app/src/projectEnvironmentRoutes.ts
@@ -65,12 +65,12 @@ export function setUpProjectEnvRoutes(
         );
       }
 
-      const unauthorizedDataset = await datasetService.verifyProjectAccessForDatasets({
+      const authorizedDatasets = await datasetService.isProjectAuthorizedForDatasets({
         authenticatedUser: res.locals.user,
         datasetIds: environmentRequest.datasetIds,
         projectId: req.params.projectId
       });
-      if (unauthorizedDataset) {
+      if (!authorizedDatasets) {
         throw Boom.forbidden(
           `${environmentRequest.projectId} does not have access to the provided dataset(s)`
         );

--- a/solutions/swb-app/src/schemas/projects/projectMetadataParser.ts
+++ b/solutions/swb-app/src/schemas/projects/projectMetadataParser.ts
@@ -12,8 +12,7 @@ export const ProjectDatasetMetadataParser = z
     id: z.string(),
     pk: z.string(),
     sk: z.string(),
-    name: z.string(),
-    permission: z.array(z.string()),
+    permission: z.string(),
     createdAt: z.string(),
     updatedAt: z.string()
   })

--- a/solutions/swb-reference/integration-tests/tests/isolated/datasets/delete.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/datasets/delete.test.ts
@@ -1,33 +1,17 @@
-import { DataSet } from '@aws/swb-app';
-import {
-  CreateDataSetRequest,
-  CreateDataSetRequestParser
-} from '@aws/swb-app/lib/dataSets/createDataSetRequestParser';
 import ClientSession from '../../../support/clientSession';
 import { PaabHelper } from '../../../support/complex/paabHelper';
-import Setup from '../../../support/setup';
 import HttpError from '../../../support/utils/HttpError';
-import RandomTextGenerator from '../../../support/utils/randomTextGenerator';
-import Settings from '../../../support/utils/settings';
 import { checkHttpError } from '../../../support/utils/utilities';
 
 describe('datasets delete negative tests', () => {
-  const setup: Setup = Setup.getSetup();
-  const settings: Settings = setup.getSettings();
   let pa1Session: ClientSession;
   let project1Id: string;
-  let project2Id: string;
   let paabHelper: PaabHelper;
-  let dataSet: DataSet;
-  let dataSetBody: CreateDataSetRequest;
-  const randomTextGenerator = new RandomTextGenerator(settings.get('runId'));
-  let dataSetName: string;
 
   beforeAll(async () => {
     paabHelper = new PaabHelper();
     const paabResources = await paabHelper.createResources();
     project1Id = paabResources.project1Id;
-    project2Id = paabResources.project2Id;
     pa1Session = paabResources.pa1Session;
     expect.hasAssertions();
   });
@@ -71,112 +55,6 @@ describe('datasets delete negative tests', () => {
           })
         );
       }
-    });
-  });
-
-  describe('when the dataset is still associated with', () => {
-    beforeEach(async () => {
-      dataSetName = randomTextGenerator.getFakeText('integration-test-dataSet');
-
-      dataSetBody = CreateDataSetRequestParser.parse({
-        storageName: settings.get('DataSetsBucketName'),
-        awsAccountId: settings.get('mainAccountId'),
-        path: dataSetName,
-        name: dataSetName,
-        region: settings.get('awsRegion'),
-        type: 'internal'
-      });
-
-      const { data: newDataSet } = await pa1Session.resources.projects
-        .project(project1Id)
-        .dataSets()
-        .create(dataSetBody, false);
-      dataSet = newDataSet;
-    });
-
-    describe('external endpoints', () => {
-      beforeEach(async () => {
-        const envBody = {
-          envTypeId: settings.get('envTypeId'),
-          envTypeConfigId: settings.get('envTypeConfigId'),
-          envType: settings.get('envType'),
-          datasetIds: [dataSet.id],
-          name: randomTextGenerator.getFakeText('dataset-name'),
-          description: 'Temporary DataSet for integration test'
-        };
-        const { data: env } = await pa1Session.resources.projects
-          .project(project1Id)
-          .environments()
-          .create(envBody);
-
-        const { data: envDetails } = await pa1Session.resources.projects
-          .project(project1Id)
-          .environments()
-          .environment(env.id)
-          .get();
-        console.log('got environment');
-        expect(envDetails).toMatchObject({
-          ENDPOINTS: expect.arrayContaining([
-            expect.objectContaining({
-              dataSetId: dataSet.id
-            })
-          ]),
-          DATASETS: expect.arrayContaining([
-            expect.objectContaining({
-              id: dataSet.id
-            })
-          ])
-        });
-
-        const { data: dataSetDetails } = await pa1Session.resources.projects
-          .project(project1Id)
-          .dataSets()
-          .dataset(dataSet.id!)
-          .get();
-        expect(dataSetDetails).toMatchObject({
-          ...dataSetBody
-        });
-      });
-
-      test('it returns a 409', async () => {
-        try {
-          await pa1Session.resources.projects.project(project1Id).dataSets().dataset(dataSet.id!).delete();
-        } catch (e) {
-          checkHttpError(
-            e,
-            new HttpError(409, {
-              error: 'Conflict',
-              message: `External endpoints found on Dataset must be removed before DataSet can be removed.`
-            })
-          );
-        }
-      });
-    });
-
-    describe('projects other than the datasets owning project', () => {
-      let associatedProjectId: string;
-      beforeEach(async () => {
-        await pa1Session.resources.projects
-          .project(project1Id)
-          .dataSets()
-          .dataset(dataSet.id!)
-          .associateWithProject(project2Id, 'read-only');
-        associatedProjectId = project2Id;
-      });
-
-      test('it returns a 409', async () => {
-        try {
-          await pa1Session.resources.projects.project(project1Id).dataSets().dataset(dataSet.id!).delete();
-        } catch (e) {
-          checkHttpError(
-            e,
-            new HttpError(409, {
-              error: 'Conflict',
-              message: `DataSet ${dataSet.id} cannot be removed because it is still associated with roles in the following project(s) ['${associatedProjectId}']`
-            })
-          );
-        }
-      });
     });
   });
 });

--- a/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
@@ -19,12 +19,14 @@ describe('multiStep dataset integration test', () => {
   const setup: Setup = Setup.getSetup();
   const settings: Settings = setup.getSettings();
 
+  let adminSession: ClientSession;
   let pa1Session: ClientSession;
   let project1Id: string;
   let project2Id: string;
 
   beforeAll(async () => {
     const paabResources = await paabHelper.createResources();
+    adminSession = paabResources.adminSession;
     project1Id = paabResources.project1Id;
     pa1Session = paabResources.pa1Session;
     project2Id = paabResources.project2Id;
@@ -112,7 +114,6 @@ describe('multiStep dataset integration test', () => {
       .associateWithProject(project2Id, 'read-only');
 
     console.log('ENSURE DUPLICATE ASSOCIATION WITH PROJECT THROWS');
-
     try {
       await pa1Session.resources.projects
         .project(project1Id)
@@ -125,6 +126,19 @@ describe('multiStep dataset integration test', () => {
         new HttpError(409, {
           error: 'Conflict',
           message: `Project ${project2Id} is already associated with Dataset ${dataSet.id}`
+        })
+      );
+    }
+
+    console.log('DELETING A DATASET STILL ASSOCIATED WITH A PROJECT FAILS');
+    try {
+      await pa1Session.resources.projects.project(project1Id).dataSets().dataset(dataSet.id!).delete();
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(409, {
+          error: 'Conflict',
+          message: `DataSet ${dataSet.id} cannot be removed because it is still associated with roles in the provided project(s)`
         })
       );
     }
@@ -170,6 +184,19 @@ describe('multiStep dataset integration test', () => {
       .dataset(dataSet.id)
       .disassociateFromProject(project2Id);
 
+    console.log('DELETE DATASET BEFORE ENDPOINT IS DELETED FAILS');
+    try {
+      await pa1Session.resources.projects.project(project1Id).dataSets().dataset(dataSet.id!).delete();
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(409, {
+          error: 'Conflict',
+          message: `External endpoints found on Dataset must be removed before DataSet can be removed.`
+        })
+      );
+    }
+
     console.log('TERMINATE ENVIRONMENT & REMOVE DATASET');
     await poll(
       async () => {
@@ -212,6 +239,27 @@ describe('multiStep dataset integration test', () => {
       (data) => data?.status === 'TERMINATED' || data?.status === 'FAILED',
       ENVIRONMENT_START_MAX_WAITING_SECONDS
     );
-    await pa1Session.resources.projects.project(project2Id).dataSets().dataset(dataSet.id).delete();
+
+    console.log('CREATE ENVIRONMENT WITH UNAUTHORIZED DATASET THROWS ERROR');
+    await adminSession.resources.projects
+      .project(project2Id)
+      .assignUserToProject(pa1Session.getUserId()!, { role: 'ProjectAdmin' });
+    try {
+      await pa1Session.resources.projects.project(project2Id).environments().create(envBody);
+    } catch (e) {
+      await adminSession.resources.projects
+        .project(project2Id)
+        .removeUserFromProject(pa1Session.getUserId()!);
+      checkHttpError(
+        e,
+        new HttpError(403, {
+          error: 'Forbidden',
+          message: `${project2Id} does not have access to the provided dataset(s)`
+        })
+      );
+    }
+    await adminSession.resources.projects.project(project2Id).removeUserFromProject(pa1Session.getUserId()!);
+
+    await pa1Session.resources.projects.project(project1Id).dataSets().dataset(dataSet.id).delete();
   });
 });

--- a/solutions/swb-reference/src/services/dataSetService.test.ts
+++ b/solutions/swb-reference/src/services/dataSetService.test.ts
@@ -263,7 +263,7 @@ describe('DataSetService', () => {
 
         test('it throws an error', async () => {
           await expect(dataSetService.removeDataSet(mockDataSet.id!, mockUser)).rejects.toThrowError(
-            `DataSet ${mockDataSet.id!} cannot be removed because it is still associated with roles in the following project(s) ['${externalProjectId}']`
+            `DataSet ${mockDataSet.id!} cannot be removed because it is still associated with roles in the provided project(s)`
           );
         });
       });

--- a/solutions/swb-reference/src/services/dataSetService.ts
+++ b/solutions/swb-reference/src/services/dataSetService.ts
@@ -11,9 +11,9 @@ import {
   DataSetPlugin,
   DataSetStoragePlugin,
   GetAccessPermissionRequest,
+  IsProjectAuthorizedForDatasetsRequest,
   PermissionsResponse,
-  PermissionsResponseParser,
-  VerifyProjectAccessForDatasetsRequest
+  PermissionsResponseParser
 } from '@aws/swb-app';
 import { ListDataSetAccessPermissionsRequest } from '@aws/swb-app/lib/dataSets/listDataSetAccessPermissionsRequestParser';
 import { ProjectAddAccessRequest } from '@aws/swb-app/lib/dataSets/projectAddAccessRequestParser';
@@ -461,10 +461,10 @@ export class DataSetService implements DataSetPlugin {
     return response;
   }
 
-  public async verifyProjectAccessForDatasets(
-    request: VerifyProjectAccessForDatasetsRequest
+  public async isProjectAuthorizedForDatasets(
+    request: IsProjectAuthorizedForDatasetsRequest
   ): Promise<boolean> {
-    let unauthorizedDataset = false;
+    let authorizedDataset = true;
     await Promise.all(
       request.datasetIds.map(async (datasetId: string): Promise<void> => {
         // Using Researcher role to verify project has access to dataset because Researcher and PA permissions
@@ -475,11 +475,11 @@ export class DataSetService implements DataSetPlugin {
           identityType: 'GROUP'
         });
         if (accessPermissions.data.permissions.length === 0) {
-          unauthorizedDataset = true;
+          authorizedDataset = false;
         }
       })
     );
-    return unauthorizedDataset;
+    return authorizedDataset;
   }
 
   private async _addAuthZPermissionsForDataset(

--- a/workbench-core/base/src/aws/helpers/dynamoDB/ddbUtil.test.ts
+++ b/workbench-core/base/src/aws/helpers/dynamoDB/ddbUtil.test.ts
@@ -3,9 +3,17 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { buildDynamoDbKey, buildDynamoDBPkSk, removeDynamoDbKeys } from './ddbUtil';
+import { buildConcatenatedSk, buildDynamoDbKey, buildDynamoDBPkSk, removeDynamoDbKeys } from './ddbUtil';
 
 describe('ddbUtil', () => {
+  describe('buildConcatenatedSk', () => {
+    test('it builds the expected key pattern', () => {
+      const key1 = 'RESOURCE#resource-1';
+      const key2 = 'RESOURCE#resource-2';
+      expect(buildConcatenatedSk([key1, key2])).toEqual(key1 + key2);
+    });
+  });
+
   describe('buildDynamoDbKey', () => {
     test('it builds the expected key pattern', () => {
       const id = 'id';

--- a/workbench-core/base/src/aws/helpers/dynamoDB/ddbUtil.ts
+++ b/workbench-core/base/src/aws/helpers/dynamoDB/ddbUtil.ts
@@ -12,6 +12,10 @@ export function buildDynamoDbKey(id: string, type: string): string {
   return `${type}#${id}`;
 }
 
+export function buildConcatenatedSk(keys: string[]): string {
+  return keys.join('');
+}
+
 export function removeDynamoDbKeys(entry: { [key: string]: never }): { [key: string]: never } {
   delete entry.pk;
   delete entry.sk;

--- a/workbench-core/base/src/index.ts
+++ b/workbench-core/base/src/index.ts
@@ -9,7 +9,12 @@ import {
   CFNTemplateParameters,
   CFNTemplateParametersParser
 } from './aws/helpers/cloudFormationTemplate';
-import { buildDynamoDbKey, buildDynamoDBPkSk, removeDynamoDbKeys } from './aws/helpers/dynamoDB/ddbUtil';
+import {
+  buildConcatenatedSk,
+  buildDynamoDbKey,
+  buildDynamoDBPkSk,
+  removeDynamoDbKeys
+} from './aws/helpers/dynamoDB/ddbUtil';
 import DynamoDBService from './aws/helpers/dynamoDB/dynamoDBService';
 import CognitoTokenService from './cognitoTokenService';
 import resourceTypeToKey from './constants/resourceTypeToKey';
@@ -73,6 +78,7 @@ export {
   CognitoTokenService,
   QueryParams,
   IamRoleCloneService,
+  buildConcatenatedSk,
   buildDynamoDbKey,
   buildDynamoDBPkSk,
   removeDynamoDbKeys,

--- a/workbench-core/environments/src/services/environmentService.ts
+++ b/workbench-core/environments/src/services/environmentService.ts
@@ -11,6 +11,7 @@ import {
   QueryParams,
   resourceTypeToKey,
   uuidWithLowercasePrefix,
+  buildConcatenatedSk,
   buildDynamoDBPkSk,
   buildDynamoDbKey,
   DEFAULT_API_PAGE_SIZE,
@@ -404,6 +405,49 @@ export class EnvironmentService {
     const key = { pk: buildDynamoDbKey(pkId, pkType), sk: buildDynamoDbKey(metaId, metaType) };
 
     await this._dynamoDBService.updateExecuteAndFormat({ key, params: { item: data } });
+  }
+
+  /**
+   * Store metadata in DDB relating the environment's project with the dataset and endpoint that gets mounted on the env
+   * @param projectId - Environment's projectId
+   * @param datasetId - Dataset that is mounted on the Environment
+   * @param endpointId - Endpoint for the Dataset that was mounted on the Environment
+   */
+  public async storeProjectDatasetEndpointRelationship(
+    projectId: string,
+    datasetId: string,
+    endpointId: string
+  ): Promise<void> {
+    const key = {
+      pk: buildDynamoDbKey(projectId, resourceTypeToKey.project),
+      sk: buildConcatenatedSk([
+        buildDynamoDbKey(datasetId, resourceTypeToKey.dataset),
+        buildDynamoDbKey(endpointId, resourceTypeToKey.endpoint)
+      ])
+    };
+
+    await this._dynamoDBService.updateExecuteAndFormat({ key, params: { item: {} } });
+  }
+
+  /**
+   * Deletes metadata in DDB that relates environment's project with the dataset and endpoint that gets mounted on the env
+   * @param projectId - Environment's projectId
+   * @param datasetId - Dataset that is mounted on the Environment
+   * @param endpointId - Endpoint for the Dataset that was mounted on the Environment
+   */
+  public async removeProjectDatasetEndpointRelationship(
+    projectId: string,
+    datasetId: string,
+    endpointId: string
+  ): Promise<void> {
+    const key = {
+      pk: buildDynamoDbKey(projectId, resourceTypeToKey.project),
+      sk: buildConcatenatedSk([
+        buildDynamoDbKey(datasetId, resourceTypeToKey.dataset),
+        buildDynamoDbKey(endpointId, resourceTypeToKey.endpoint)
+      ])
+    };
+    await this._dynamoDBService.deleteItem({ key });
   }
 
   /**

--- a/workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts
+++ b/workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts
@@ -101,6 +101,7 @@ describe('EnvironmentLifecycleHelper', () => {
     helper.dataSetService.addDataSetExternalEndpointForGroup = jest.fn();
     helper.dataSetService.getDataSet = jest.fn();
     helper.environmentService.addMetadata = jest.fn();
+    helper.environmentService.storeProjectDatasetEndpointRelationship = jest.fn();
 
     // OPERATE
     const response = await helper.getDatasetsToMount(datasetIds, envMetadata, ['sampleKeyARN1']);
@@ -172,6 +173,7 @@ describe('EnvironmentLifecycleHelper', () => {
       };
     });
     helper.environmentService.addMetadata = jest.fn();
+    helper.environmentService.storeProjectDatasetEndpointRelationship = jest.fn();
 
     // OPERATE & CHECK
     await expect(

--- a/workbench-core/environments/src/utilities/environmentLifecycleHelper.ts
+++ b/workbench-core/environments/src/utilities/environmentLifecycleHelper.ts
@@ -205,6 +205,11 @@ export default class EnvironmentLifecycleHelper {
             roles: []
           }
         );
+        await this.environmentService.removeProjectDatasetEndpointRelationship(
+          envMetadata.projectId,
+          endpoint.dataSetId,
+          endpoint.id
+        );
       })
     );
   }
@@ -253,7 +258,7 @@ export default class EnvironmentLifecycleHelper {
           dataSetId: endpoint.dataSetId,
           endPointUrl: endpoint.endPointUrl,
           path: endpoint.path,
-          storageArn: `arn:aws:s3:::${dataSet.storageName}` // TODO: Handle non-S3 storage types in future
+          storageArn: `arn:aws:s3:::${dataSet.storageName}`
         };
 
         await this.environmentService.addMetadata(
@@ -262,6 +267,12 @@ export default class EnvironmentLifecycleHelper {
           mountObject.endpointId,
           resourceTypeToKey.endpoint,
           endpointObj
+        );
+
+        await this.environmentService.storeProjectDatasetEndpointRelationship(
+          envMetadata.projectId,
+          dataSetId,
+          mountObject.endpointId
         );
 
         endpointsCreated.push(endpointObj);


### PR DESCRIPTION
Description of changes:
* If a Dataset is still mounted on an environment, the project of that environment cannot have its access removed until that environment has been terminated
* Fixed bug where project losing access to a Dataset was not removing its access to upload file API
* Added integ tests to make sure a user in two projects, but only one project has access to a dataset, does not carry over the permissions from one project to another
* Environment creation given a Dataset that they do not have access to throws a 403 error and does not create an entry for the failed environment in the database
* Fixed incorrect project to dataset metadata that used the wrong resource type
* Fixed dataset permissions to include condition on projectId so that users will no longer be able to pass in anything for projectId when calling Dataset APIs
* Delete Dataset isolated tests that required an environment have been moved into multistep Dataset test

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.