### PR TITLE
fix: set maximum input length for create account requests

### DIFF
--- a/common/changes/@aws/workbench-core-accounts/thingut-hosting-account-text-limit_2023-06-05-17-34.json
+++ b/common/changes/@aws/workbench-core-accounts/thingut-hosting-account-text-limit_2023-06-05-17-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-accounts",
+      "comment": "update error message",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-accounts"
+}

--- a/common/changes/@aws/workbench-core-base/thingut-hosting-account-text-limit_2023-06-05-17-34.json
+++ b/common/changes/@aws/workbench-core-base/thingut-hosting-account-text-limit_2023-06-05-17-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-base",
+      "comment": "update error message for accounts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-base"
+}

--- a/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/create.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/create.test.ts
@@ -2,6 +2,7 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
+import { lengthValidationMessage } from '@aws/workbench-core-base';
 import _ from 'lodash';
 import ClientSession from '../../../support/clientSession';
 import { AccountHelper } from '../../../support/complex/accountHelper';
@@ -66,6 +67,71 @@ describe('awsAccounts create negative tests', () => {
             new HttpError(400, {
               error: 'Bad Request',
               message: 'awsAccountId: must be a 12 digit number'
+            })
+          );
+        }
+      });
+      test('with hostingAccountHandlerRoleArn that is too long it throws a validation error', async () => {
+        try {
+          const body = { ...validLaunchParameters };
+          body.hostingAccountHandlerRoleArn =
+            'arn:aws:iam::123456789012:role/message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-abcde-hosting-account-role';
+          await adminSession.resources.accounts.create(body, false);
+        } catch (e) {
+          checkHttpError(
+            e,
+            new HttpError(400, {
+              error: 'Bad Request',
+              message: `hostingAccountHandlerRoleArn: ${lengthValidationMessage(400)}`
+            })
+          );
+        }
+      });
+      test('with envMgmtRoleArn that is too long it throws a validation error', async () => {
+        try {
+          const body = { ...validLaunchParameters };
+          body.envMgmtRoleArn =
+            'arn:aws:iam::123456789012:role/message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-abcdefghijklmnopq-env-mgmt';
+          await adminSession.resources.accounts.create(body, false);
+        } catch (e) {
+          checkHttpError(
+            e,
+            new HttpError(400, {
+              error: 'Bad Request',
+              message: `envMgmtRoleArn: ${lengthValidationMessage(400)}`
+            })
+          );
+        }
+      });
+      test('with name that is too long it throws a validation error', async () => {
+        try {
+          const body = { ...validLaunchParameters };
+          body.name =
+            'string-longer-than-112-characters-string-longer-than-112-characters-string-longer-than-112-characters-abcdefghijk';
+          await adminSession.resources.accounts.create(body, false);
+        } catch (e) {
+          checkHttpError(
+            e,
+            new HttpError(400, {
+              error: 'Bad Request',
+              message: `name: ${lengthValidationMessage(112)}`
+            })
+          );
+        }
+      });
+      test('with externalId that is too long it throws a validation error', async () => {
+        try {
+          const body = { ...validLaunchParameters };
+          body.externalId =
+            'message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-message-that-is-longer-than-400-characters-abcdefghijklmn';
+          await adminSession.resources.accounts.create(body, false);
+        } catch (e) {
+          checkHttpError(
+            e,
+            new HttpError(400, {
+              error: 'Bad Request',
+              message:
+                'externalId: must contain only letters, numbers, hyphens, underscores, plus, equal, comma, period, at (@), colon (:), and forward slash (/). String length must be between 2 and 400 characters inclusively'
             })
           );
         }

--- a/workbench-core/accounts/src/models/accounts/createAccountRequest.ts
+++ b/workbench-core/accounts/src/models/accounts/createAccountRequest.ts
@@ -11,7 +11,7 @@ export const CreateAccountRequestParser = z.object({
   awsAccountId: z.string().awsAccountId().required(),
   envMgmtRoleArn: z.string().envMgmtRoleArn().required(),
   hostingAccountHandlerRoleArn: z.string().hostingAccountHandlerRoleArn().required(),
-  externalId: z.string().required()
+  externalId: z.string().externalId().required()
 });
 
 export type CreateAccountRequest = z.infer<typeof CreateAccountRequestParser>;

--- a/workbench-core/base/src/utilities/textUtil.test.ts
+++ b/workbench-core/base/src/utilities/textUtil.test.ts
@@ -206,7 +206,7 @@ describe('textUtil', () => {
   });
   describe('lengthValidationMessage', () => {
     test('returns validation message', () => {
-      expect(lengthValidationMessage(3)).toEqual('Input must be less than 3 characters');
+      expect(lengthValidationMessage(3)).toEqual('Input must be 3 characters or less');
     });
   });
 

--- a/workbench-core/base/src/utilities/textUtil.ts
+++ b/workbench-core/base/src/utilities/textUtil.ts
@@ -29,6 +29,10 @@ const swbDescriptionMessage: string =
 const swbDescriptionRegExpAsString: string = ['^[A-Za-z0-9-_. ]+$', emtpyStringAsString].join('|');
 const swbDescriptionMaxLength: number = 400;
 
+const externalIdMessage: string =
+  'must contain only letters, numbers, hyphens, underscores, plus, equal, comma, period, at (@), colon (:), and forward slash (/). String length must be between 2 and 400 characters inclusively';
+const externalIdRegExpAsString: string = '^[A-Za-z0-9-_+=,.@:\\/]{2,400}$';
+
 const nonEmptyMessage: string = 'optional, but cannot be empty if included';
 const invalidIdMessage: string = 'Invalid ID';
 const invalidEmailMessage: string = 'Invalid Email';
@@ -43,10 +47,12 @@ const awsAccountIdRegExpAsString: string = '^[0-9]{12}$';
 
 const envMgmtRoleArnMessage: string = 'must be a valid envMgmtRoleArn';
 const envMgmtRoleArnRegExpAsString: string = '^arn:aws:iam::[0-9]{12}:role\\/[\\w-]+-env-mgmt$';
+const envMgmtRoleArnMaxLength: number = 400;
 
 const hostingAccountHandlerRoleArnMessage: string = 'must be a valid hostingAccountHandlerRoleArn';
 const hostingAccountHandlerRoleArnRegExpAsString: string =
   '^arn:aws:iam::[0-9]{12}:role\\/[\\w-]+hosting-account-role$';
+const hostingAccountHandlerRoleArnMaxLength: number = 400;
 
 const awsRegionMessage: string = 'must be valid AWS region';
 const awsRegionRegExpAsString: string = '^(us|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\\d$';
@@ -70,7 +76,7 @@ const userIdRegExpString: string = `^${uuidRegExpAsString}$`;
 const uuidRegExp: RegExp = new RegExp(uuidRegExpAsString);
 
 function lengthValidationMessage(length: number): string {
-  return `Input must be less than ${length} characters`;
+  return `Input must be ${length} characters or less`;
 }
 
 function uuidWithLowercasePrefixRegExp(prefix: string): RegExp {
@@ -131,6 +137,11 @@ function costCenterIdRegex(): RegExp {
 function accountIdRegex(): RegExp {
   // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
   return new RegExp(accountIdRegExpString);
+}
+
+function externalIdRegExp(): RegExp {
+  // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
+  return new RegExp(externalIdRegExpAsString);
 }
 
 function awsRegionRegex(): RegExp {
@@ -210,6 +221,10 @@ export {
   datasetIdRegex,
   envMgmtRoleArnRegExp,
   envMgmtRoleArnMessage,
+  envMgmtRoleArnMaxLength,
   hostingAccountHandlerRoleArnMessage,
-  hostingAccountHandlerRoleArnRegExp
+  hostingAccountHandlerRoleArnRegExp,
+  hostingAccountHandlerRoleArnMaxLength,
+  externalIdMessage,
+  externalIdRegExp
 };

--- a/workbench-core/base/src/utilities/validatorHelper.test.ts
+++ b/workbench-core/base/src/utilities/validatorHelper.test.ts
@@ -266,7 +266,7 @@ describe('tests for zod.swbName', () => {
       ];
       test.each(invalidObjects)('returns required message', (invalidObject) => {
         expect(() => validateAndParse<SwbNameType>(zodParser, invalidObject)).toThrowError(
-          `id: Input must be less than ${swbNameMaxLength} characters`
+          `id: Input must be ${swbNameMaxLength} characters or less`
         );
       });
     });
@@ -308,7 +308,7 @@ describe('tests for zod.swbDescription', () => {
       ];
       test.each(invalidObjects)('returns required message', (invalidObject) => {
         expect(() => validateAndParse<SwbDescriptionType>(zodParser, invalidObject)).toThrowError(
-          `id: Input must be less than ${swbDescriptionMaxLength} characters`
+          `id: Input must be ${swbDescriptionMaxLength} characters or less`
         );
       });
     });

--- a/workbench-core/base/src/utilities/validatorHelper.ts
+++ b/workbench-core/base/src/utilities/validatorHelper.ts
@@ -37,8 +37,12 @@ import {
   datasetIdRegex,
   envMgmtRoleArnRegExp,
   envMgmtRoleArnMessage,
+  envMgmtRoleArnMaxLength,
   hostingAccountHandlerRoleArnMessage,
-  hostingAccountHandlerRoleArnRegExp
+  hostingAccountHandlerRoleArnRegExp,
+  externalIdMessage,
+  externalIdRegExp,
+  hostingAccountHandlerRoleArnMaxLength
 } from './textUtil';
 
 interface ZodPagination {
@@ -61,6 +65,7 @@ declare module 'zod' {
     envId: () => ZodString;
     costCenterId: () => ZodString;
     accountId: () => ZodString;
+    externalId: () => ZodString;
     awsRegion: () => ZodString;
     optionalNonEmpty: () => ZodOptional<ZodString>;
     awsAccountId: () => ZodString;
@@ -132,6 +137,10 @@ z.ZodString.prototype.accountId = function (): ZodString {
   return this.regex(accountIdRegex(), { message: invalidIdMessage });
 };
 
+z.ZodString.prototype.externalId = function (): ZodString {
+  return this.regex(externalIdRegExp(), { message: externalIdMessage });
+};
+
 z.ZodString.prototype.sshKeyId = function (): ZodString {
   return this.regex(sshKeyIdRegex(), { message: invalidIdMessage });
 };
@@ -153,11 +162,15 @@ z.ZodString.prototype.awsAccountId = function (): ZodString {
 };
 
 z.ZodString.prototype.envMgmtRoleArn = function (): ZodString {
-  return this.regex(envMgmtRoleArnRegExp(), { message: envMgmtRoleArnMessage });
+  return this.max(envMgmtRoleArnMaxLength, {
+    message: lengthValidationMessage(envMgmtRoleArnMaxLength)
+  }).regex(envMgmtRoleArnRegExp(), { message: envMgmtRoleArnMessage });
 };
 
 z.ZodString.prototype.hostingAccountHandlerRoleArn = function (): ZodString {
-  return this.regex(hostingAccountHandlerRoleArnRegExp(), { message: hostingAccountHandlerRoleArnMessage });
+  return this.max(hostingAccountHandlerRoleArnMaxLength, {
+    message: lengthValidationMessage(hostingAccountHandlerRoleArnMaxLength)
+  }).regex(hostingAccountHandlerRoleArnRegExp(), { message: hostingAccountHandlerRoleArnMessage });
 };
 
 z.ZodString.prototype.awsRegion = function (): ZodString {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
fix: set maximum input length for create account requests

Max Arn length is 2048, min is 20, so we'll set the max length as 400 for RSW
https://docs.aws.amazon.com/IAM/latest/APIReference/API_Policy.html

External id max length is 1224. so wel'll set the max length as 400 for RSW
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.