### PR TITLE
fix: address edge cases for adding/removing owning project to dataset

### DIFF
--- a/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
@@ -106,7 +106,6 @@ describe('multiStep dataset integration test', () => {
     });
 
     console.log('ASSOCIATE WITH PROJECT');
-
     await pa1Session.resources.projects
       .project(project1Id)
       .dataSets()
@@ -130,6 +129,23 @@ describe('multiStep dataset integration test', () => {
       );
     }
 
+    console.log('ASSOCIATE WITH OWNING PROJECT THROWS');
+    try {
+      await pa1Session.resources.projects
+        .project(project1Id)
+        .dataSets()
+        .dataset(dataSet.id)
+        .associateWithProject(project1Id, 'read-only');
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(409, {
+          error: 'Conflict',
+          message: `${project1Id} already owns this dataset`
+        })
+      );
+    }
+
     console.log('DELETING A DATASET STILL ASSOCIATED WITH A PROJECT FAILS');
     try {
       await pa1Session.resources.projects.project(project1Id).dataSets().dataset(dataSet.id!).delete();
@@ -139,6 +155,23 @@ describe('multiStep dataset integration test', () => {
         new HttpError(409, {
           error: 'Conflict',
           message: `DataSet ${dataSet.id} cannot be removed because it is still associated with roles in the provided project(s)`
+        })
+      );
+    }
+
+    console.log('DISASSOCIATING WITH OWNING PROJECT THROWS');
+    try {
+      await pa1Session.resources.projects
+        .project(project1Id)
+        .dataSets()
+        .dataset(dataSet.id)
+        .disassociateFromProject(project1Id);
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(409, {
+          error: 'Conflict',
+          message: `${project1Id} cannot remove access from ${dataSet.id} for the ProjectAdmin because it owns that dataset.`
         })
       );
     }

--- a/solutions/swb-reference/src/services/dataSetService.ts
+++ b/solutions/swb-reference/src/services/dataSetService.ts
@@ -312,6 +312,10 @@ export class DataSetService implements DataSetPlugin {
   public async addAccessForProject(request: ProjectAddAccessRequest): Promise<PermissionsResponse> {
     const projectAdmin = getProjectAdminRole(request.projectId);
     const projectResearcher = getResearcherRole(request.projectId);
+    const requestedDataset = await this.getDataSet(request.dataSetId, request.authenticatedUser);
+    if (requestedDataset.owner === projectAdmin) {
+      throw new ConflictError(`${request.projectId} already owns this dataset`);
+    }
 
     const dataset: Associable = {
       type: resourceTypeToKey.dataset,


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Associating/disassociating a project that owns a dataset will throw a 4xx error

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.