### PR TITLE
fix: add pagination to get user roles call

### DIFF
--- a/common/changes/@aws/workbench-core-base/yanyu-cognito-fix_2023-06-05-19-46.json
+++ b/common/changes/@aws/workbench-core-base/yanyu-cognito-fix_2023-06-05-19-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-base",
+      "comment": "add cognito service",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-base"
+}

--- a/common/changes/@aws/workbench-core-user-management/yanyu-cognito-fix_2023-06-05-19-46.json
+++ b/common/changes/@aws/workbench-core-user-management/yanyu-cognito-fix_2023-06-05-19-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-user-management",
+      "comment": "add pagination to user role call",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-user-management"
+}

--- a/workbench-core/base/src/aws/awsService.ts
+++ b/workbench-core/base/src/aws/awsService.ts
@@ -23,6 +23,7 @@ import { STS } from '@aws-sdk/client-sts';
 import { Credentials } from '@aws-sdk/types';
 import AppRegistryService from './helpers/appRegistryService';
 import CloudformationService from './helpers/cloudformationService';
+import CognitoService from './helpers/cognitoService';
 import DynamoDBService from './helpers/dynamoDB/dynamoDBService';
 import S3Service from './helpers/s3Service';
 import ServiceCatalogService from './helpers/serviceCatalogService';
@@ -53,6 +54,7 @@ export default class AwsService {
     ddb: DynamoDBService;
     serviceCatalog: ServiceCatalogService;
     appRegistryService: AppRegistryService;
+    cognito: CognitoService;
   };
 
   public constructor(options: {
@@ -102,7 +104,8 @@ export default class AwsService {
         this.clients.appRegistry,
         this.clients.cloudformation,
         this.clients.serviceQuotas
-      )
+      ),
+      cognito: new CognitoService(this.clients.cognito)
     };
   }
 

--- a/workbench-core/base/src/aws/helpers/cognitoService.test.ts
+++ b/workbench-core/base/src/aws/helpers/cognitoService.test.ts
@@ -1,0 +1,63 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  AdminListGroupsForUserCommand,
+  CognitoIdentityProvider,
+  ServiceInputTypes,
+  ServiceOutputTypes
+} from '@aws-sdk/client-cognito-identity-provider';
+import { AwsStub, mockClient } from 'aws-sdk-client-mock';
+import CognitoService from './cognitoService';
+
+describe('appRegistryService', () => {
+  let cognitoService: CognitoService;
+  let mockCognitoClient: AwsStub<ServiceInputTypes, ServiceOutputTypes>;
+
+  const mockGroupOne = {
+    CreationDate: new Date('2023-06-01T20:38:30.383Z'),
+    Description: undefined,
+    GroupName: 'proj-12345678-1234-1234-1234-12345678910#Researcher',
+    LastModifiedDate: new Date('2023-06-01T20:38:30.383Z'),
+    Precedence: undefined,
+    RoleArn: undefined,
+    UserPoolId: 'us-west-2_123456789'
+  };
+  const mockGroupTwo = {
+    CreationDate: new Date('2023-06-01T20:38:30.383Z'),
+    Description: undefined,
+    GroupName: 'proj-12345678-1234-1234-1234-12345678910#Admin',
+    LastModifiedDate: new Date('2023-06-01T20:38:30.383Z'),
+    Precedence: undefined,
+    RoleArn: undefined,
+    UserPoolId: 'us-west-2_123456789'
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCognitoClient = mockClient(CognitoIdentityProvider);
+    cognitoService = new CognitoService(new CognitoIdentityProvider({}));
+  });
+
+  describe('getUserGroups', () => {
+    test('Return all groups when responses were paginated', async () => {
+      mockCognitoClient
+        .on(AdminListGroupsForUserCommand)
+        .resolvesOnce({ Groups: [mockGroupOne], NextToken: '1234567' })
+        .resolvesOnce({ Groups: [mockGroupTwo] });
+      await expect(cognitoService.getUserGroups('fakeUserPoolId', 'fakeUserName')).resolves.toStrictEqual([
+        mockGroupOne,
+        mockGroupTwo
+      ]);
+    });
+
+    test('Return all groups when responses were not paginated', async () => {
+      mockCognitoClient.on(AdminListGroupsForUserCommand).resolvesOnce({ Groups: [mockGroupTwo] });
+      await expect(cognitoService.getUserGroups('fakeUserPoolId', 'fakeUserName')).resolves.toStrictEqual([
+        mockGroupTwo
+      ]);
+    });
+  });
+});

--- a/workbench-core/base/src/aws/helpers/cognitoService.ts
+++ b/workbench-core/base/src/aws/helpers/cognitoService.ts
@@ -1,0 +1,30 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  CognitoIdentityProvider,
+  GroupType,
+  paginateAdminListGroupsForUser
+} from '@aws-sdk/client-cognito-identity-provider';
+
+export default class CognitoService {
+  private _cognito: CognitoIdentityProvider;
+  public constructor(cognito: CognitoIdentityProvider) {
+    this._cognito = cognito;
+  }
+  /*
+   * Get groups of a user
+   */
+  public async getUserGroups(userPoolId: string, userName: string): Promise<GroupType[]> {
+    const groups = [];
+    for await (const page of paginateAdminListGroupsForUser(
+      { client: this._cognito },
+      { UserPoolId: userPoolId, Username: userName }
+    )) {
+      // page contains a single paginated output.
+      groups.push(...(page.Groups as GroupType[]));
+    }
+    return groups;
+  }
+}

--- a/workbench-core/user-management/src/plugins/cognitoUserManagementPlugin.test.ts
+++ b/workbench-core/user-management/src/plugins/cognitoUserManagementPlugin.test.ts
@@ -235,7 +235,7 @@ describe('CognitoUserManagementPlugin tests', () => {
         ],
         Enabled: true
       });
-      cognitoMock.on(AdminListGroupsForUserCommand).resolves({});
+      cognitoMock.on(AdminListGroupsForUserCommand).resolves({ Groups: [] });
 
       const user = await plugin.getUser(userInfo.id);
 
@@ -334,7 +334,7 @@ describe('CognitoUserManagementPlugin tests', () => {
     });
 
     it('should return an empty array for the Users roles when no roles are assigned to it', async () => {
-      cognitoMock.on(AdminListGroupsForUserCommand).resolves({});
+      cognitoMock.on(AdminListGroupsForUserCommand).resolves({ Groups: [] });
 
       const userRoles = await plugin.getUserRoles(userInfo.id);
 
@@ -751,7 +751,7 @@ describe('CognitoUserManagementPlugin tests', () => {
           }
         ]
       });
-      cognitoMock.on(AdminListGroupsForUserCommand).resolves({});
+      cognitoMock.on(AdminListGroupsForUserCommand).resolves({ Groups: [] });
 
       const users = await plugin.listUsers({});
 
@@ -1065,7 +1065,7 @@ describe('CognitoUserManagementPlugin tests', () => {
   describe('addUserToRole tests', () => {
     beforeEach(() => {
       ddbMock.on(UpdateItemCommand).resolves({});
-      cognitoMock.on(AdminListGroupsForUserCommand).resolves({});
+      cognitoMock.on(AdminListGroupsForUserCommand).resolves({ Groups: [] });
     });
 
     describe('when user has reached role limit', () => {
@@ -1084,7 +1084,6 @@ describe('CognitoUserManagementPlugin tests', () => {
 
     it('should add the requested User to the group when the user id and group both exist', async () => {
       const addUserToRoleMock = cognitoMock.on(AdminAddUserToGroupCommand).resolves({});
-
       await plugin.addUserToRole(userInfo.id, roles[0]);
 
       expect(addUserToRoleMock.calls().length).toBe(2);

--- a/workbench-core/user-management/src/plugins/cognitoUserManagementPlugin.ts
+++ b/workbench-core/user-management/src/plugins/cognitoUserManagementPlugin.ts
@@ -37,7 +37,7 @@ export class CognitoUserManagementPlugin implements UserManagementPlugin {
   private _userPoolId: string;
   private _aws: AwsService;
   private _tempRoleAccessSettings?: { ddbService: DynamoDBService; ttl?: number };
-  public readonly userRoleLimit: number = 25;
+  public readonly userRoleLimit: number = 100;
 
   /**
    *
@@ -119,10 +119,7 @@ export class CognitoUserManagementPlugin implements UserManagementPlugin {
    */
   public async getUserRoles(id: string): Promise<string[]> {
     try {
-      const { Groups: groups } = await this._aws.clients.cognito.adminListGroupsForUser({
-        UserPoolId: this._userPoolId,
-        Username: id
-      });
+      const groups = await this._aws.helpers.cognito.getUserGroups(this._userPoolId, id);
 
       if (!groups) {
         return [];


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Deployed to AWS account 
* Tested with users having 30+ roles, verified all roles are retrieved successfully 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.