### PR TITLE
chore(list-env): add integ test for pageSize exceed max

### DIFF
--- a/common/changes/@aws/swb-reference/janeyu-pageSize_2023-06-27-20-55.json
+++ b/common/changes/@aws/swb-reference/janeyu-pageSize_2023-06-27-20-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-reference",
+      "comment": "integ test",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/swb-reference"
+}

--- a/solutions/swb-reference/integration-tests/tests/isolated/environments/list.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/environments/list.test.ts
@@ -150,6 +150,25 @@ describe('list environments', () => {
       }
     });
 
+    describe('page size too large', () => {
+      const pageSize = '101';
+      const queryParams = { pageSize };
+
+      test('it throws 400 error', async () => {
+        try {
+          await itAdminSession.resources.environments.get(queryParams);
+        } catch (e) {
+          checkHttpError(
+            e,
+            new HttpError(400, {
+              error: 'Bad Request',
+              message: `pageSize: Must be Between 1 and 100`
+            })
+          );
+        }
+      });
+    });
+
     test('list project environments when project does not exist', async () => {
       const fakeProjectId: string = 'proj-12345678-1234-1234-1234-123456789012';
       try {
@@ -210,6 +229,28 @@ describe('list environments', () => {
           e,
           new HttpError(403, {
             error: 'User is not authorized'
+          })
+        );
+      }
+    });
+  });
+
+  describe('page size too large', () => {
+    const pageSize = '101';
+    const queryParams = { pageSize };
+
+    test('it throws 400 error', async () => {
+      try {
+        await itAdminSession.resources.projects
+          .project(projectId2)
+          .environments()
+          .listProjectEnvironments(queryParams);
+      } catch (e) {
+        checkHttpError(
+          e,
+          new HttpError(400, {
+            error: 'Bad Request',
+            message: `pageSize: Must be Between 1 and 100`
           })
         );
       }


### PR DESCRIPTION
Issue #, if available:

Description of changes: V900862033


Checklist:

add  integ tests to prove the two api calls (listEnvironments or listProjectEnvironments) have a limit of 100 pageSize
* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.