### PR TITLE
feat: main equal to hosting

### DIFF
--- a/common/changes/@aws/swb-reference/chore-main-hosting-same_2023-07-05-18-07.json
+++ b/common/changes/@aws/swb-reference/chore-main-hosting-same_2023-07-05-18-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-reference",
+      "comment": "feat: main account can be hosting",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/swb-reference"
+}

--- a/common/changes/@aws/workbench-core-accounts/chore-main-hosting-same_2023-07-05-18-07.json
+++ b/common/changes/@aws/workbench-core-accounts/chore-main-hosting-same_2023-07-05-18-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-accounts",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@aws/workbench-core-accounts"
+}

--- a/common/changes/@aws/workbench-core-accounts/chore-main-hosting-same_2023-07-05-18-07.json
+++ b/common/changes/@aws/workbench-core-accounts/chore-main-hosting-same_2023-07-05-18-07.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@aws/workbench-core-accounts",
-      "comment": "",
-      "type": "none"
+      "comment": "feat: main account can be hosting",
+      "type": "patch"
     }
   ],
   "packageName": "@aws/workbench-core-accounts"

--- a/solutions/swb-reference/src/templates/onboard-account-byon.cfn.yaml
+++ b/solutions/swb-reference/src/templates/onboard-account-byon.cfn.yaml
@@ -77,6 +77,7 @@ Metadata:
 
 Conditions:
   enableFlowLogs: !Equals [!Ref EnableFlowLogs, true]
+  hostNotEqualToMain: !Not [!Equals [!Ref MainAccountId, !Ref AWS::AccountId]]
 
 Mappings:
   Solution:
@@ -546,6 +547,7 @@ Resources:
       TargetKeyId: !Ref EncryptionKey
 
   StateChangeEventRuleMainRouting:
+    Condition: hostNotEqualToMain
     Type: 'AWS::Events::Rule'
     Properties:
       Description: Routes environment state changes to the main event bus
@@ -570,6 +572,7 @@ Resources:
             - Arn
 
   StateChangeEventBridgeIAMrole:
+    Condition: hostNotEqualToMain
     Type: 'AWS::IAM::Role'
     Properties:
       AssumeRolePolicyDocument:

--- a/solutions/swb-reference/src/templates/onboard-account.cfn.yaml
+++ b/solutions/swb-reference/src/templates/onboard-account.cfn.yaml
@@ -74,6 +74,7 @@ Metadata:
 
 Conditions:
   enableFlowLogs: !Equals [!Ref EnableFlowLogs, true]
+  hostNotEqualToMain: !Not [!Equals [!Ref MainAccountId, !Ref AWS::AccountId]]
 
 Mappings:
   Solution:
@@ -596,6 +597,7 @@ Resources:
       TargetKeyId: !Ref EncryptionKey
 
   StateChangeEventRuleMainRouting:
+    Condition: hostNotEqualToMain
     Type: 'AWS::Events::Rule'
     Properties:
       Description: Routes environment state changes to the main event bus
@@ -620,6 +622,7 @@ Resources:
             - Arn
 
   StateChangeEventBridgeIAMrole:
+    Condition: hostNotEqualToMain
     Type: 'AWS::IAM::Role'
     Properties:
       AssumeRolePolicyDocument:


### PR DESCRIPTION
Issue #, if available:
GALI-1567

Description of changes:
- Skipped a few post deployment steps to ensure main account can be onboarded as hosting account.
- Verified workspace launch/stop/start/terminate work as expected
- Verified AccountHandler lambda runs successfully
- Verified postDeployment script runs successfully

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.